### PR TITLE
add qt6 to abi_migration_branches

### DIFF
--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -2,6 +2,9 @@ azure:
   settings_win:
     variables:
       CONDA_BLD_PATH: C:\bld\
+bot:
+  abi_migration_branches:
+  - qt6
 build_platform:
   linux_aarch64: linux_aarch64
   osx_arm64: osx_64


### PR DESCRIPTION
I don't fully understand why main=5 and qt6 has a separate branch[^1], but in any case, in order to facilitate the long-term transition from 5->6, we need to keep rebuilding qt6 for various abi migrations. The bot gets this info from the main branch, hence this PR.

[^1]: rather than main being on the newest version and previous LTS versions getting their own branch