### PR TITLE
Depend on libsqlite not sqlite

### DIFF
--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -38,6 +38,8 @@ libevent:
 - 2.1.10
 libpng:
 - '1.6'
+libsqlite:
+- '3'
 libxml2:
 - '2.10'
 nspr:
@@ -48,8 +50,6 @@ openssl:
 - 1.1.1
 pulseaudio:
 - '16.1'
-sqlite:
-- '3'
 target_platform:
 - linux-64
 zip_keys:

--- a/.ci_support/linux_aarch64_.yaml
+++ b/.ci_support/linux_aarch64_.yaml
@@ -42,6 +42,8 @@ libevent:
 - 2.1.10
 libpng:
 - '1.6'
+libsqlite:
+- '3'
 libxml2:
 - '2.10'
 nspr:
@@ -52,8 +54,6 @@ openssl:
 - 1.1.1
 pulseaudio:
 - '16.1'
-sqlite:
-- '3'
 target_platform:
 - linux-aarch64
 zip_keys:

--- a/.ci_support/osx_64_.yaml
+++ b/.ci_support/osx_64_.yaml
@@ -26,6 +26,8 @@ krb5:
 - '1.19'
 libpng:
 - '1.6'
+libsqlite:
+- '3'
 macos_machine:
 - x86_64-apple-darwin13.4.0
 nspr:
@@ -34,8 +36,6 @@ nss:
 - '3'
 openssl:
 - 1.1.1
-sqlite:
-- '3'
 target_platform:
 - osx-64
 zip_keys:

--- a/.ci_support/osx_arm64_.yaml
+++ b/.ci_support/osx_arm64_.yaml
@@ -24,6 +24,8 @@ krb5:
 - '1.19'
 libpng:
 - '1.6'
+libsqlite:
+- '3'
 macos_machine:
 - arm64-apple-darwin20.0.0
 nspr:
@@ -32,8 +34,6 @@ nss:
 - '3'
 openssl:
 - 1.1.1
-sqlite:
-- '3'
 target_platform:
 - osx-arm64
 zip_keys:

--- a/.ci_support/win_64_.yaml
+++ b/.ci_support/win_64_.yaml
@@ -20,10 +20,10 @@ krb5:
 - '1.19'
 libpng:
 - '1.6'
+libsqlite:
+- '3'
 openssl:
 - 1.1.1
-sqlite:
-- '3'
 target_platform:
 - win-64
 zlib:

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -150,7 +150,14 @@ if [[ $(uname) == "Linux" ]]; then
 #                -ltcg \
 #                --disable-new-dtags \
 
-  make -j${MAKE_JOBS}
+
+  # Shorten the log to a little further on travis and to make the log files smaller
+  # than 50 MB.
+  # Without these sed commands, one gets about 4_497_973 characters in 30 mins
+  # With these sed commands, we get about 1_054_756 characters for getting as
+  # far in the build process.
+  make -j${MAKE_JOBS} | sed "s/^g++.*-o/g++ [...] -o/" | sed "s/-DQT.* //"
+  # make -j${MAKE_JOBS}
   make install
 fi
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -46,7 +46,7 @@ source:
     folder: opengl32sw                                                                                            # [win64]
 
 build:
-  number: 2
+  number: 3
   detect_binary_files_with_prefix: true
   run_exports:
     - {{ pin_subpackage('qt-main', max_pin='x.x') }}
@@ -150,7 +150,7 @@ requirements:
     - libpng
     - nspr                               # [unix]
     - nss                                # [unix]
-    - sqlite
+    - libsqlite
     - mysql-devel                        # [not win]
     - postgresql                         # [not win]
     - zlib


### PR DESCRIPTION
I recently split off squlite into two packages, one containings the command line application, that depends on readline, the other being the executable, that does not pull in readline at build time.

This helps export the correct package
https://github.com/conda-forge/sqlite-feedstock/pull/79 https://github.com/conda-forge/conda-forge-pinning-feedstock/pull/3777

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
