### PR TITLE
gtk3 subpackage for better desktop on linux

### DIFF
--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -4,6 +4,8 @@ c_compiler:
 - gcc
 c_compiler_version:
 - '11'
+cairo:
+- '1'
 cdt_name:
 - cos7
 channel_sources:
@@ -23,6 +25,8 @@ expat:
 fontconfig:
 - '2'
 freetype:
+- '2'
+gdk_pixbuf:
 - '2'
 glib:
 - '2'
@@ -50,6 +54,8 @@ nss:
 - '3'
 openssl:
 - '3'
+pango:
+- '1.50'
 postgresql:
 - '15'
 pulseaudio:

--- a/.ci_support/linux_aarch64_.yaml
+++ b/.ci_support/linux_aarch64_.yaml
@@ -6,6 +6,8 @@ c_compiler:
 - gcc
 c_compiler_version:
 - '11'
+cairo:
+- '1'
 cdt_arch:
 - aarch64
 cdt_name:
@@ -27,6 +29,8 @@ expat:
 fontconfig:
 - '2'
 freetype:
+- '2'
+gdk_pixbuf:
 - '2'
 glib:
 - '2'
@@ -54,6 +58,8 @@ nss:
 - '3'
 openssl:
 - '3'
+pango:
+- '1.50'
 postgresql:
 - '15'
 pulseaudio:

--- a/.ci_support/linux_ppc64le_.yaml
+++ b/.ci_support/linux_ppc64le_.yaml
@@ -4,6 +4,8 @@ c_compiler:
 - gcc
 c_compiler_version:
 - '11'
+cairo:
+- '1'
 cdt_name:
 - cos7
 channel_sources:
@@ -23,6 +25,8 @@ expat:
 fontconfig:
 - '2'
 freetype:
+- '2'
+gdk_pixbuf:
 - '2'
 glib:
 - '2'
@@ -50,6 +54,8 @@ nss:
 - '3'
 openssl:
 - '3'
+pango:
+- '1.50'
 postgresql:
 - '15'
 pulseaudio:

--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ Current release info
 
 | Name | Downloads | Version | Platforms |
 | --- | --- | --- | --- |
+| [![Conda Recipe](https://img.shields.io/badge/recipe-qt--gtk--platformtheme-green.svg)](https://anaconda.org/conda-forge/qt-gtk-platformtheme) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/qt-gtk-platformtheme.svg)](https://anaconda.org/conda-forge/qt-gtk-platformtheme) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/qt-gtk-platformtheme.svg)](https://anaconda.org/conda-forge/qt-gtk-platformtheme) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/qt-gtk-platformtheme.svg)](https://anaconda.org/conda-forge/qt-gtk-platformtheme) |
 | [![Conda Recipe](https://img.shields.io/badge/recipe-qt--main-green.svg)](https://anaconda.org/conda-forge/qt-main) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/qt-main.svg)](https://anaconda.org/conda-forge/qt-main) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/qt-main.svg)](https://anaconda.org/conda-forge/qt-main) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/qt-main.svg)](https://anaconda.org/conda-forge/qt-main) |
 
 Installing qt-main
@@ -108,41 +109,41 @@ conda config --add channels conda-forge
 conda config --set channel_priority strict
 ```
 
-Once the `conda-forge` channel has been enabled, `qt-main` can be installed with `conda`:
+Once the `conda-forge` channel has been enabled, `qt-gtk-platformtheme, qt-main` can be installed with `conda`:
 
 ```
-conda install qt-main
-```
-
-or with `mamba`:
-
-```
-mamba install qt-main
-```
-
-It is possible to list all of the versions of `qt-main` available on your platform with `conda`:
-
-```
-conda search qt-main --channel conda-forge
+conda install qt-gtk-platformtheme qt-main
 ```
 
 or with `mamba`:
 
 ```
-mamba search qt-main --channel conda-forge
+mamba install qt-gtk-platformtheme qt-main
+```
+
+It is possible to list all of the versions of `qt-gtk-platformtheme` available on your platform with `conda`:
+
+```
+conda search qt-gtk-platformtheme --channel conda-forge
+```
+
+or with `mamba`:
+
+```
+mamba search qt-gtk-platformtheme --channel conda-forge
 ```
 
 Alternatively, `mamba repoquery` may provide more information:
 
 ```
 # Search all versions available on your platform:
-mamba repoquery search qt-main --channel conda-forge
+mamba repoquery search qt-gtk-platformtheme --channel conda-forge
 
-# List packages depending on `qt-main`:
-mamba repoquery whoneeds qt-main --channel conda-forge
+# List packages depending on `qt-gtk-platformtheme`:
+mamba repoquery whoneeds qt-gtk-platformtheme --channel conda-forge
 
-# List dependencies of `qt-main`:
-mamba repoquery depends qt-main --channel conda-forge
+# List dependencies of `qt-gtk-platformtheme`:
+mamba repoquery depends qt-gtk-platformtheme --channel conda-forge
 ```
 
 

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -75,6 +75,9 @@ if [[ $(uname) == "Linux" ]]; then
       SKIPS+=(-skip); SKIPS+=(qttools)
       SKIPS+=(-skip); SKIPS+=(qtlocation)
       SKIPS+=(-skip); SKIPS+=(qt3d)
+      EXTRA_OPTIONS=""
+    else
+      EXTRA_OPTIONS="-gstreamer 1.0"
     fi
 
     if [ ${target_platform} == "linux-aarch64" ] || [ ${target_platform} == "linux-ppc64le" ]; then
@@ -114,7 +117,6 @@ if [[ $(uname) == "Linux" ]]; then
                 -verbose \
                 -skip wayland \
                 -skip qtwebengine \
-                -gstreamer 1.0 \
                 -system-libjpeg \
                 -system-libpng \
                 -system-zlib \
@@ -123,6 +125,7 @@ if [[ $(uname) == "Linux" ]]; then
                 -plugin-sql-sqlite \
                 -plugin-sql-mysql \
                 -plugin-sql-psql \
+                -gtk \
                 -xcb \
                 -xcb-xlib \
                 -qt-pcre \
@@ -144,6 +147,7 @@ if [[ $(uname) == "Linux" ]]; then
                 -D FC_WEIGHT_EXTRABLACK=215 \
                 -D FC_WEIGHT_ULTRABLACK=FC_WEIGHT_EXTRABLACK \
                 -D GLX_GLXEXT_PROTOTYPES \
+                ${EXTRA_OPTIONS} \
                 "${SKIPS[@]+"${SKIPS[@]}"}"
 
 # ltcg bloats a test tar.bz2 from 24524263 to 43257121 (built with the following skips)
@@ -159,6 +163,9 @@ if [[ $(uname) == "Linux" ]]; then
   make -j${MAKE_JOBS} | sed "s/^g++.*-o/g++ [...] -o/" | sed "s/-DQT.* //"
   # make -j${MAKE_JOBS}
   make install
+
+  # Will be installed as part of the GTK extension
+  rm $PREFIX/plugins/platformthemes/libqgtk3.so
 fi
 
 if [[ ${HOST} =~ .*darwin.* ]]; then

--- a/recipe/install_qt-gtk-platformtheme.sh
+++ b/recipe/install_qt-gtk-platformtheme.sh
@@ -1,0 +1,9 @@
+set -ex
+
+ls -lah
+ls -lah qt-build
+
+mkdir -p "$PREFIX/lib/qt5/plugins/platformthemes"
+install \
+    qt-build/qtbase/plugins/platformthemes/libqgtk3.so \
+    "$PREFIX/plugins/platformthemes/libqgtk3.so"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -36,16 +36,26 @@ source:
     folder: opengl32sw                                                                                            # [win64]
 
 build:
-  number: 6
+  number: 7
   detect_binary_files_with_prefix: true
   run_exports:
     - {{ pin_subpackage('qt-main', max_pin='x.x') }}
-  missing_dso_whitelist:  # [osx]
-    - /usr/lib/libbsm.0.dylib  # [osx]
-    - /usr/lib/libcups.2.dylib  # [osx]
-    - /usr/lib/libresolv.9.dylib  # [osx]
-    - /usr/lib/libsandbox.1.dylib  # [osx]
+  ignore_run_exports_from:             # [linux]
+    - gtk3                             # [linux]
+    - pango                            # [linux]
+    - atk                              # [linux]
+    - cairo                            # [linux]
+    - gdk-pixbuf                       # [linux]
+  missing_dso_whitelist:               # [unix]
+    - /usr/lib/libbsm.0.dylib          # [osx]
+    - /usr/lib/libcups.2.dylib         # [osx]
+    - /usr/lib/libresolv.9.dylib       # [osx]
+    - /usr/lib/libsandbox.1.dylib      # [osx]
     - '/System/Library/Frameworks/CoreLocation.framework/**'  # [osx]
+    # GTK3 decided to use the CDTs for these two packages
+    # So we assume that they will be installed by the system
+    - '*/libX11.so*'                   # [linux]
+    - '*/libXext.so*'                  # [linux]
 
 requirements:
   build:
@@ -63,12 +73,11 @@ requirements:
     - {{ cdt('mesa-dri-drivers') }}      # [linux]
     - {{ cdt('libxau-devel') }}          # [linux]
     - {{ cdt('alsa-lib-devel') }}        # [linux]
-    - {{ cdt('gtk2-devel') }}            # [linux]
-    - {{ cdt('gtkmm24-devel') }}         # [linux]
     - {{ cdt('libdrm-devel') }}          # [linux]
     - {{ cdt('libxcomposite-devel') }}   # [linux]
     - {{ cdt('libxcursor-devel') }}      # [linux]
     - {{ cdt('libxi-devel') }}           # [linux]
+    - {{ cdt('libxinerama-devel') }}     # [linux]
     - {{ cdt('libxrandr-devel') }}       # [linux]
     - {{ cdt('pciutils-devel') }}        # [linux]
     - {{ cdt('libxscrnsaver-devel') }}   # [linux]
@@ -164,6 +173,12 @@ requirements:
     - alsa-lib                           # [linux]
     - krb5
     - harfbuzz                           # [linux]
+    # Specifically for the platform plugin gtk3
+    - gtk3                               # [linux]
+    - pango                              # [linux]
+    - atk                                # [linux]
+    - cairo                              # [linux]
+    - gdk-pixbuf                         # [linux]
   run:
     - {{ pin_compatible("nss") }}        # [unix]
     - {{ pin_compatible("nspr") }}       # [unix]
@@ -194,8 +209,6 @@ test:
     - {{ cdt('mesa-dri-drivers') }}      # [linux]
     - {{ cdt('libxau-devel') }}          # [linux]
     - {{ cdt('alsa-lib-devel') }}        # [linux]
-    - {{ cdt('gtk2-devel') }}            # [linux]
-    - {{ cdt('gtkmm24-devel') }}         # [linux]
     - {{ cdt('libdrm-devel') }}          # [linux]
     - {{ cdt('libxcomposite-devel') }}   # [linux]
     - {{ cdt('libxcursor-devel') }}      # [linux]
@@ -227,6 +240,39 @@ test:
     - test/test_qmimedatabase.cpp
     - xcodebuild
     - xcrun
+
+outputs:
+  - name: qt-main
+  - name: qt-gtk-platformtheme
+    script: install_qt-gtk-platformtheme.sh
+    build:
+      skip: true  # [not linux]
+
+    requirements:
+      build:
+        # Add these to generate the SHA correctly
+        - {{ compiler('c') }}
+        - {{ compiler('cxx') }}
+        - sysroot_linux-64 2.17
+        # openssl here ensures that we can install the same qt-main
+        # package during the build process
+        - openssl
+      host:
+        # openssl here ensures that we can install the same qt-main
+        # package during the build process
+        - openssl
+        - {{ pin_subpackage('qt-main', exact=True) }}
+        # Specify these dependencies so that we pickup the run_exports
+        - gtk3
+        - pango
+        - atk
+        - cairo
+        - gdk-pixbuf
+      run:
+        - {{ pin_subpackage('qt-main', exact=True) }}
+    test:
+      commands:
+        - test -f ${PREFIX}/plugins/platformthemes/libqgtk3.so
 
 about:
   home: https://qt.io

--- a/recipe/run_test.bat
+++ b/recipe/run_test.bat
@@ -1,5 +1,4 @@
 @ECHO ON
-
 :: Test for presence of sql plugin
 if not exist %LIBRARY_PREFIX%\plugins\sqldrivers\qsqlite.dll exit 1
 

--- a/recipe/run_test.sh
+++ b/recipe/run_test.sh
@@ -2,7 +2,9 @@
 set -ex
 
 # test for presence of sql plugin
-test -f $PREFIX/plugins/sqldrivers/libqsqlite${SHLIB_EXT}
+test   -f "${PREFIX}/plugins/sqldrivers/libqsqlite${SHLIB_EXT}"
+# gtk3 platform theme is installed as a separate package
+test ! -f "${PREFIX}/plugins/platformthemes/libqgtk3${SHLIB_EXT}"
 
 ls
 cd test


### PR DESCRIPTION
The following creates a subpckage:
```
qt-gtk-platformtheme
```

with associated GTK dependencies to create better desktop integration for QT applications on linux where users use GTK based desktops (Ubuntu Gnome)

Specifically, this adds the file:

```
plugins/platformthemes/libqgtk3.so
```
which enables qt to find the GTK theme that might be installed by the user.


Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
