### PR TITLE
Qt 6.x Fix for xcb plugin not present on linux (#148)

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -61,7 +61,7 @@ if [[ "$CONDA_BUILD_CROSS_COMPILATION" = "1" ]]; then
 fi
 
 if [[ $(uname) == "Linux" ]]; then
-  CMAKE_ARGS="${CMAKE_ARGS} -DFEATURE_egl=ON -DFEATURE_eglfs=ON"
+  CMAKE_ARGS="${CMAKE_ARGS} -DFEATURE_egl=ON -DFEATURE_eglfs=ON -DFEATURE_xcb=ON -DFEATURE_xcb_xlib=ON -DFEATURE_xkbcommon=ON"
 fi
 
 mkdir build && cd build

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -31,7 +31,7 @@ source:
     folder: opengl32sw                                                                                            # [win64]
 
 build:
-  number: 4
+  number: 5
   detect_binary_files_with_prefix: true
   run_exports:
     - {{ pin_subpackage('qt6-main', max_pin='x.x') }}
@@ -176,6 +176,7 @@ requirements:
     - xcb-util-keysyms                   # [linux]
     - xcb-util-image                     # [linux]
     - xcb-util-renderutil                # [linux]
+    - xcb-util-cursor                    # [linux]
     - xorg-libx11                        # [linux]
     - xorg-libxext                       # [linux]
     - xorg-libxdamage                    # [linux]
@@ -199,6 +200,7 @@ requirements:
     - xcb-util-keysyms                   # [linux]
     - xcb-util-image                     # [linux]
     - xcb-util-renderutil                # [linux]
+    - xcb-util-cursor                    # [linux]
     - {{ pin_compatible("libclang") }}
   run_constrained:
     - __osx >={{ MACOSX_DEPLOYMENT_TARGET|default("10.14") }}  # [osx and x86_64]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -31,7 +31,7 @@ source:
     folder: opengl32sw                                                                                            # [win64]
 
 build:
-  number: 5
+  number: 6
   detect_binary_files_with_prefix: true
   run_exports:
     - {{ pin_subpackage('qt6-main', max_pin='x.x') }}


### PR DESCRIPTION
Require `xcb-util-cursor`: https://github.com/conda-forge/staged-recipes/pull/22568

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
