### PR TITLE
Use -no-optimize-size on Linux to fix QML

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -93,6 +93,9 @@ if [[ $(uname) == "Linux" ]]; then
     # Had been trying with:
     #   -sysroot ${BUILD_PREFIX}/${HOST}/sysroot
     # .. but it probably requires changing -L ${BUILD_PREFIX}/${HOST}/sysroot/usr/lib64 to -L /usr/lib64
+    # -no-optimize-size is passed as a workaround for https://github.com/conda-forge/qt-feedstock/issues/241 and
+    # https://bugreports.qt.io/browse/QTBUG-99545 . Once we bump the release to qt 5.15.11, we can change it back
+    # to -optimize-size for consistency with Windows and macOS
     ../configure -prefix ${PREFIX} \
                 -libdir ${PREFIX}/lib \
                 -bindir ${PREFIX}/bin \
@@ -134,7 +137,7 @@ if [[ $(uname) == "Linux" ]]; then
                 -no-libudev \
                 -no-avx \
                 -no-avx2 \
-                -optimize-size \
+                -no-optimize-size \
                 ${REDUCE_RELOCATIONS} \
                 -cups \
                 -openssl-linked \

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -41,7 +41,7 @@ source:
     folder: opengl32sw                                                                                            # [win64]
 
 build:
-  number: 9
+  number: 10
   detect_binary_files_with_prefix: true
   run_exports:
     - {{ pin_subpackage('qt-main', max_pin='x.x') }}


### PR DESCRIPTION
As workaround for https://github.com/conda-forge/qt-feedstock/issues/241 and https://bugreports.qt.io/browse/QTBUG-99545

Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
