### PR TITLE
Harfbuzz7 libevent2112 for qt5

### DIFF
--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -3,7 +3,7 @@ alsa_lib:
 c_compiler:
 - gcc
 c_compiler_version:
-- '11'
+- '12'
 cdt_name:
 - cos7
 channel_sources:
@@ -13,7 +13,7 @@ channel_targets:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '11'
+- '12'
 dbus:
 - '1'
 docker_image:
@@ -29,13 +29,13 @@ glib:
 gstreamer:
 - '1.22'
 harfbuzz:
-- '6'
+- '7'
 icu:
 - '72'
 krb5:
 - '1.20'
 libevent:
-- 2.1.10
+- 2.1.12
 libjpeg_turbo:
 - 2.1.5
 libpng:

--- a/.ci_support/linux_aarch64_.yaml
+++ b/.ci_support/linux_aarch64_.yaml
@@ -5,7 +5,7 @@ alsa_lib:
 c_compiler:
 - gcc
 c_compiler_version:
-- '11'
+- '12'
 cdt_arch:
 - aarch64
 cdt_name:
@@ -17,7 +17,7 @@ channel_targets:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '11'
+- '12'
 dbus:
 - '1'
 docker_image:
@@ -33,13 +33,13 @@ glib:
 gstreamer:
 - '1.22'
 harfbuzz:
-- '6'
+- '7'
 icu:
 - '72'
 krb5:
 - '1.20'
 libevent:
-- 2.1.10
+- 2.1.12
 libjpeg_turbo:
 - 2.1.5
 libpng:

--- a/.ci_support/linux_ppc64le_.yaml
+++ b/.ci_support/linux_ppc64le_.yaml
@@ -3,7 +3,7 @@ alsa_lib:
 c_compiler:
 - gcc
 c_compiler_version:
-- '11'
+- '12'
 cdt_name:
 - cos7
 channel_sources:
@@ -13,7 +13,7 @@ channel_targets:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '11'
+- '12'
 dbus:
 - '1'
 docker_image:
@@ -29,13 +29,13 @@ glib:
 gstreamer:
 - '1.22'
 harfbuzz:
-- '6'
+- '7'
 icu:
 - '72'
 krb5:
 - '1.20'
 libevent:
-- 2.1.10
+- 2.1.12
 libjpeg_turbo:
 - 2.1.5
 libpng:

--- a/.ci_support/migrations/harfbuzz7.yaml
+++ b/.ci_support/migrations/harfbuzz7.yaml
@@ -1,0 +1,7 @@
+__migrator:
+  build_number: 1
+  kind: version
+  migration_number: 1
+harfbuzz:
+- '7'
+migrator_ts: 1681100035.1884027

--- a/.ci_support/migrations/libevent2112.yaml
+++ b/.ci_support/migrations/libevent2112.yaml
@@ -1,0 +1,7 @@
+__migrator:
+  build_number: 1
+  kind: version
+  migration_number: 1
+libevent:
+- 2.1.12
+migrator_ts: 1682629086.7193437

--- a/.ci_support/osx_64_.yaml
+++ b/.ci_support/osx_64_.yaml
@@ -5,7 +5,7 @@ MACOSX_SDK_VERSION:
 c_compiler:
 - clang
 c_compiler_version:
-- '14'
+- '15'
 channel_sources:
 - conda-forge
 channel_targets:
@@ -13,7 +13,7 @@ channel_targets:
 cxx_compiler:
 - clangxx
 cxx_compiler_version:
-- '14'
+- '15'
 glib:
 - '2'
 gstreamer:

--- a/.ci_support/osx_arm64_.yaml
+++ b/.ci_support/osx_arm64_.yaml
@@ -3,7 +3,7 @@ MACOSX_DEPLOYMENT_TARGET:
 c_compiler:
 - clang
 c_compiler_version:
-- '14'
+- '15'
 channel_sources:
 - conda-forge
 channel_targets:
@@ -11,7 +11,7 @@ channel_targets:
 cxx_compiler:
 - clangxx
 cxx_compiler_version:
-- '14'
+- '15'
 glib:
 - '2'
 gstreamer:

--- a/.ci_support/win_64_.yaml
+++ b/.ci_support/win_64_.yaml
@@ -5,7 +5,7 @@ channel_sources:
 channel_targets:
 - conda-forge main
 curl:
-- '7'
+- '8'
 cxx_compiler:
 - vs2019
 glib:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -41,7 +41,7 @@ source:
     folder: opengl32sw                                                                                            # [win64]
 
 build:
-  number: 10
+  number: 11
   detect_binary_files_with_prefix: true
   run_exports:
     - {{ pin_subpackage('qt-main', max_pin='x.x') }}


### PR DESCRIPTION
For some reason, the bot didn't rerun the migrations on the main branch

- libevent https://github.com/conda-forge/qt-main-feedstock/pull/156
- harfbuzz https://github.com/conda-forge/qt-main-feedstock/pull/152

This only affects linux.

- [ ] aarch build
- [ ] ppc64le build

Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
