### PR TITLE
DRAFT: Split shared/dynamic libraries from static/build artifacts

### DIFF
--- a/.azure-pipelines/azure-pipelines-osx.yml
+++ b/.azure-pipelines/azure-pipelines-osx.yml
@@ -5,7 +5,7 @@
 jobs:
 - job: osx
   pool:
-    vmImage: macOS-12
+    vmImage: macOS-13
   strategy:
     matrix:
       osx_64_:

--- a/.azure-pipelines/azure-pipelines-win.yml
+++ b/.azure-pipelines/azure-pipelines-win.yml
@@ -14,31 +14,16 @@ jobs:
   timeoutInMinutes: 360
   variables:
     CONDA_BLD_PATH: C:\bld\
+    MINIFORGE_HOME: C:\Miniforge
     UPLOAD_TEMP: D:\\tmp
 
   steps:
-
-    - task: PythonScript@0
-      displayName: 'Download Miniforge'
-      inputs:
-        scriptSource: inline
-        script: |
-          import urllib.request
-          url = 'https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-Windows-x86_64.exe'
-          path = r"$(Build.ArtifactStagingDirectory)/Miniforge.exe"
-          urllib.request.urlretrieve(url, path)
-
-    - script: |
-        start /wait "" %BUILD_ARTIFACTSTAGINGDIRECTORY%\Miniforge.exe /InstallationType=JustMe /RegisterPython=0 /S /D=C:\Miniforge
-      displayName: Install Miniforge
-
-    - powershell: Write-Host "##vso[task.prependpath]C:\Miniforge\Scripts"
-      displayName: Add conda to PATH
 
     - script: |
         call ".scripts\run_win_build.bat"
       displayName: Run Windows build
       env:
+        MINIFORGE_HOME: $(MINIFORGE_HOME)
         PYTHONUNBUFFERED: 1
         CONFIG: $(CONFIG)
         CI: azure

--- a/.scripts/build_steps.sh
+++ b/.scripts/build_steps.sh
@@ -31,12 +31,12 @@ pkgs_dirs:
 solver: libmamba
 
 CONDARC
+mv /opt/conda/conda-meta/history /opt/conda/conda-meta/history.$(date +%Y-%m-%d-%H-%M-%S)
+echo > /opt/conda/conda-meta/history
+micromamba install --root-prefix ~/.conda --prefix /opt/conda \
+    --yes --override-channels --channel conda-forge --strict-channel-priority \
+    pip  python=3.12 conda-build conda-forge-ci-setup=4 "conda-build>=24.1"
 export CONDA_LIBMAMBA_SOLVER_NO_CHANNELS_FROM_INSTALLED=1
-
-mamba install --update-specs --yes --quiet --channel conda-forge --strict-channel-priority \
-    pip mamba conda-build conda-forge-ci-setup=4 "conda-build>=24.1"
-mamba update --update-specs --yes --quiet --channel conda-forge --strict-channel-priority \
-    pip mamba conda-build conda-forge-ci-setup=4 "conda-build>=24.1"
 
 # set up the condarc
 setup_conda_rc "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"
@@ -76,8 +76,8 @@ else
         --extra-meta flow_run_id="${flow_run_id:-}" remote_url="${remote_url:-}" sha="${sha:-}"
     ( startgroup "Inspecting artifacts" ) 2> /dev/null
 
-    # inspect_artifacts was only added in conda-forge-ci-setup 4.6.0
-    command -v inspect_artifacts >/dev/null 2>&1 && inspect_artifacts || echo "inspect_artifacts needs conda-forge-ci-setup >=4.6.0"
+    # inspect_artifacts was only added in conda-forge-ci-setup 4.9.4
+    command -v inspect_artifacts >/dev/null 2>&1 && inspect_artifacts --recipe-dir "${RECIPE_ROOT}" -m "${CONFIG_FILE}" || echo "inspect_artifacts needs conda-forge-ci-setup >=4.9.4"
 
     ( endgroup "Inspecting artifacts" ) 2> /dev/null
     ( startgroup "Validating outputs" ) 2> /dev/null

--- a/.scripts/run_osx_build.sh
+++ b/.scripts/run_osx_build.sh
@@ -7,28 +7,39 @@ source .scripts/logging_utils.sh
 set -xe
 
 MINIFORGE_HOME=${MINIFORGE_HOME:-${HOME}/miniforge3}
+MINIFORGE_HOME=${MINIFORGE_HOME%/} # remove trailing slash
 
-( startgroup "Installing a fresh version of Miniforge" ) 2> /dev/null
-
-MINIFORGE_URL="https://github.com/conda-forge/miniforge/releases/latest/download"
-MINIFORGE_FILE="Miniforge3-MacOSX-$(uname -m).sh"
-curl -L -O "${MINIFORGE_URL}/${MINIFORGE_FILE}"
-rm -rf ${MINIFORGE_HOME}
-bash $MINIFORGE_FILE -b -p ${MINIFORGE_HOME}
-
-( endgroup "Installing a fresh version of Miniforge" ) 2> /dev/null
+( startgroup "Provisioning base env with micromamba" ) 2> /dev/null
+MICROMAMBA_VERSION="1.5.10-0"
+if [[ "$(uname -m)" == "arm64" ]]; then
+  osx_arch="osx-arm64"
+else
+  osx_arch="osx-64"
+fi
+MICROMAMBA_URL="https://github.com/mamba-org/micromamba-releases/releases/download/${MICROMAMBA_VERSION}/micromamba-${osx_arch}"
+MAMBA_ROOT_PREFIX="${MINIFORGE_HOME}-micromamba-$(date +%s)"
+echo "Downloading micromamba ${MICROMAMBA_VERSION}"
+micromamba_exe="$(mktemp -d)/micromamba"
+curl -L -o "${micromamba_exe}" "${MICROMAMBA_URL}"
+chmod +x "${micromamba_exe}"
+echo "Creating environment"
+"${micromamba_exe}" create --yes --root-prefix "${MAMBA_ROOT_PREFIX}" --prefix "${MINIFORGE_HOME}" \
+  --channel conda-forge \
+  pip python=3.12 conda-build conda-forge-ci-setup=4 "conda-build>=24.1"
+echo "Moving pkgs cache from ${MAMBA_ROOT_PREFIX} to ${MINIFORGE_HOME}"
+mv "${MAMBA_ROOT_PREFIX}/pkgs" "${MINIFORGE_HOME}"
+echo "Cleaning up micromamba"
+rm -rf "${MAMBA_ROOT_PREFIX}" "${micromamba_exe}" || true
+( endgroup "Provisioning base env with micromamba" ) 2> /dev/null
 
 ( startgroup "Configuring conda" ) 2> /dev/null
 
-source ${MINIFORGE_HOME}/etc/profile.d/conda.sh
+source "${MINIFORGE_HOME}/etc/profile.d/conda.sh"
 conda activate base
 export CONDA_SOLVER="libmamba"
 export CONDA_LIBMAMBA_SOLVER_NO_CHANNELS_FROM_INSTALLED=1
 
-mamba install --update-specs --quiet --yes --channel conda-forge --strict-channel-priority \
-    pip mamba conda-build conda-forge-ci-setup=4 "conda-build>=24.1"
-mamba update --update-specs --yes --quiet --channel conda-forge --strict-channel-priority \
-    pip mamba conda-build conda-forge-ci-setup=4 "conda-build>=24.1"
+
 
 
 
@@ -88,8 +99,8 @@ else
 
     ( startgroup "Inspecting artifacts" ) 2> /dev/null
 
-    # inspect_artifacts was only added in conda-forge-ci-setup 4.6.0
-    command -v inspect_artifacts >/dev/null 2>&1 && inspect_artifacts || echo "inspect_artifacts needs conda-forge-ci-setup >=4.6.0"
+    # inspect_artifacts was only added in conda-forge-ci-setup 4.9.4
+    command -v inspect_artifacts >/dev/null 2>&1 && inspect_artifacts --recipe-dir ./recipe -m ./.ci_support/${CONFIG}.yaml || echo "inspect_artifacts needs conda-forge-ci-setup >=4.9.4"
 
     ( endgroup "Inspecting artifacts" ) 2> /dev/null
     ( startgroup "Validating outputs" ) 2> /dev/null

--- a/.scripts/run_win_build.bat
+++ b/.scripts/run_win_build.bat
@@ -3,29 +3,51 @@
 :: changes to this script, consider a proposal to conda-smithy so that other feedstocks can also
 :: benefit from the improvement.
 
-:: Note: we assume a Miniforge installation is available
-
 :: INPUTS (required environment variables)
 :: CONFIG: name of the .ci_support/*.yaml file for this job
 :: CI: azure, github_actions, or unset
+:: MINIFORGE_HOME: where to install the base conda environment
 :: UPLOAD_PACKAGES: true or false
 :: UPLOAD_ON_BRANCH: true or false
 
 setlocal enableextensions enabledelayedexpansion
 
+if "%MINIFORGE_HOME%"=="" set "MINIFORGE_HOME=%USERPROFILE%\Miniforge3"
+:: Remove trailing backslash, if present
+if "%MINIFORGE_HOME:~-1%"=="\" set "MINIFORGE_HOME=%MINIFORGE_HOME:~0,-1%"
+call :start_group "Provisioning base env with micromamba"
+set "MAMBA_ROOT_PREFIX=%MINIFORGE_HOME%-micromamba-%RANDOM%"
+set "MICROMAMBA_VERSION=1.5.10-0"
+set "MICROMAMBA_URL=https://github.com/mamba-org/micromamba-releases/releases/download/%MICROMAMBA_VERSION%/micromamba-win-64"
+set "MICROMAMBA_TMPDIR=%TMP%\micromamba-%RANDOM%"
+set "MICROMAMBA_EXE=%MICROMAMBA_TMPDIR%\micromamba.exe"
+
+echo Downloading micromamba %MICROMAMBA_VERSION%
+if not exist "%MICROMAMBA_TMPDIR%" mkdir "%MICROMAMBA_TMPDIR%"
+certutil -urlcache -split -f "%MICROMAMBA_URL%" "%MICROMAMBA_EXE%"
+if !errorlevel! neq 0 exit /b !errorlevel!
+
+echo Creating environment
+call "%MICROMAMBA_EXE%" create --yes --root-prefix "%MAMBA_ROOT_PREFIX%" --prefix "%MINIFORGE_HOME%" ^
+    --channel conda-forge ^
+    pip python=3.12 conda-build conda-forge-ci-setup=4 "conda-build>=24.1"
+if !errorlevel! neq 0 exit /b !errorlevel!
+echo Moving pkgs cache from %MAMBA_ROOT_PREFIX% to %MINIFORGE_HOME%
+move /Y "%MAMBA_ROOT_PREFIX%\pkgs" "%MINIFORGE_HOME%"
+if !errorlevel! neq 0 exit /b !errorlevel!
+echo Removing %MAMBA_ROOT_PREFIX%
+del /S /Q "%MAMBA_ROOT_PREFIX%"
+del /S /Q "%MICROMAMBA_TMPDIR%"
+call :end_group
+
 call :start_group "Configuring conda"
 
 :: Activate the base conda environment
-call activate base
+call "%MINIFORGE_HOME%\Scripts\activate.bat"
 :: Configure the solver
 set "CONDA_SOLVER=libmamba"
 if !errorlevel! neq 0 exit /b !errorlevel!
 set "CONDA_LIBMAMBA_SOLVER_NO_CHANNELS_FROM_INSTALLED=1"
-
-:: Provision the necessary dependencies to build the recipe later
-echo Installing dependencies
-mamba.exe install pip mamba conda-build conda-forge-ci-setup=4 "conda-build>=24.1" -c conda-forge --strict-channel-priority --yes
-if !errorlevel! neq 0 exit /b !errorlevel!
 
 :: Set basic configuration
 echo Setting up configuration
@@ -59,8 +81,8 @@ conda-build.exe "recipe" -m .ci_support\%CONFIG%.yaml --suppress-variables %EXTR
 if !errorlevel! neq 0 exit /b !errorlevel!
 
 call :start_group "Inspecting artifacts"
-:: inspect_artifacts was only added in conda-forge-ci-setup 4.6.0
-WHERE inspect_artifacts >nul 2>nul && inspect_artifacts || echo "inspect_artifacts needs conda-forge-ci-setup >=4.6.0"
+:: inspect_artifacts was only added in conda-forge-ci-setup 4.9.4
+WHERE inspect_artifacts >nul 2>nul && inspect_artifacts --recipe-dir ".\recipe" -m .ci_support\%CONFIG%.yaml || echo "inspect_artifacts needs conda-forge-ci-setup >=4.9.4"
 call :end_group
 
 :: Prepare some environment variables for the upload step

--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ Current release info
 
 | Name | Downloads | Version | Platforms |
 | --- | --- | --- | --- |
+| [![Conda Recipe](https://img.shields.io/badge/recipe-libqt5-green.svg)](https://anaconda.org/conda-forge/libqt5) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/libqt5.svg)](https://anaconda.org/conda-forge/libqt5) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/libqt5.svg)](https://anaconda.org/conda-forge/libqt5) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/libqt5.svg)](https://anaconda.org/conda-forge/libqt5) |
 | [![Conda Recipe](https://img.shields.io/badge/recipe-qt--main-green.svg)](https://anaconda.org/conda-forge/qt-main) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/qt-main.svg)](https://anaconda.org/conda-forge/qt-main) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/qt-main.svg)](https://anaconda.org/conda-forge/qt-main) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/qt-main.svg)](https://anaconda.org/conda-forge/qt-main) |
 
 Installing qt-main
@@ -108,41 +109,41 @@ conda config --add channels conda-forge
 conda config --set channel_priority strict
 ```
 
-Once the `conda-forge` channel has been enabled, `qt-main` can be installed with `conda`:
+Once the `conda-forge` channel has been enabled, `libqt5, qt-main` can be installed with `conda`:
 
 ```
-conda install qt-main
-```
-
-or with `mamba`:
-
-```
-mamba install qt-main
-```
-
-It is possible to list all of the versions of `qt-main` available on your platform with `conda`:
-
-```
-conda search qt-main --channel conda-forge
+conda install libqt5 qt-main
 ```
 
 or with `mamba`:
 
 ```
-mamba search qt-main --channel conda-forge
+mamba install libqt5 qt-main
+```
+
+It is possible to list all of the versions of `libqt5` available on your platform with `conda`:
+
+```
+conda search libqt5 --channel conda-forge
+```
+
+or with `mamba`:
+
+```
+mamba search libqt5 --channel conda-forge
 ```
 
 Alternatively, `mamba repoquery` may provide more information:
 
 ```
 # Search all versions available on your platform:
-mamba repoquery search qt-main --channel conda-forge
+mamba repoquery search libqt5 --channel conda-forge
 
-# List packages depending on `qt-main`:
-mamba repoquery whoneeds qt-main --channel conda-forge
+# List packages depending on `libqt5`:
+mamba repoquery whoneeds libqt5 --channel conda-forge
 
-# List dependencies of `qt-main`:
-mamba repoquery depends qt-main --channel conda-forge
+# List dependencies of `libqt5`:
+mamba repoquery depends libqt5 --channel conda-forge
 ```
 
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -2,7 +2,32 @@
 # update the conda-forge.yml and/or the recipe/meta.yaml.
 # -*- mode: yaml -*-
 
-jobs:
-  - template: ./.azure-pipelines/azure-pipelines-linux.yml
-  - template: ./.azure-pipelines/azure-pipelines-osx.yml
-  - template: ./.azure-pipelines/azure-pipelines-win.yml
+stages:
+- stage: Check
+  jobs:
+    - job: Skip
+      pool:
+        vmImage: 'ubuntu-22.04'
+      variables:
+        DECODE_PERCENTS: 'false'
+        RET: 'true'
+      steps:
+      - checkout: self
+        fetchDepth: '2'
+      - bash: |
+          git_log=`git log --max-count=1 --skip=1 --pretty=format:"%B" | tr "\n" " "`
+          echo "##vso[task.setvariable variable=log]$git_log"
+        displayName: Obtain commit message
+      - bash: echo "##vso[task.setvariable variable=RET]false"
+        condition: or(contains(variables.log, '[skip azp]'), contains(variables.log, '[azp skip]'), contains(variables.log, '[skip ci]'), contains(variables.log, '[ci skip]'))
+        displayName: Skip build?
+      - bash: echo "##vso[task.setvariable variable=start_main;isOutput=true]$RET"
+        name: result
+        displayName: Export result
+- stage: Build
+  condition: and(succeeded(), eq(dependencies.Check.outputs['Skip.result.start_main'], 'true'))
+  dependsOn: Check
+  jobs:
+    - template: ./.azure-pipelines/azure-pipelines-linux.yml
+    - template: ./.azure-pipelines/azure-pipelines-osx.yml
+    - template: ./.azure-pipelines/azure-pipelines-win.yml

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,7 +1,8 @@
 {% set version = "5.15.8" %}
+{% set library = "Library/" if (target_platform == "win-64") else "" %}
 
 package:
-  name: qt-main
+  name: qt-main-split
   version: {{ version }}
 
 source:
@@ -64,7 +65,7 @@ source:
     folder: opengl32sw                                                                                            # [win64]
 
 build:
-  number: 26
+  number: 27
   detect_binary_files_with_prefix: true
   run_exports:
     - {{ pin_subpackage('qt-main', max_pin='x.x') }}
@@ -179,54 +180,271 @@ requirements:
     - xorg-xf86vidmodeproto              # [linux]
     # qtlocation requires mapbox-gl-native that uses libbost-headers
     - libboost-headers
-  run:
-    - {{ pin_compatible("nss") }}        # [unix]
-    - {{ pin_compatible("nspr") }}       # [unix]
-    - libxcb                             # [linux]
-    # Adding the following xcb-util run requirements resolves issue
-    # that may exhibit as segfault due to missing libraries
-    # in some lighter weight linux installations
-    # https://github.com/conda-forge/qt-main-feedstock/issues/32
-    - xcb-util-wm                        # [linux]
-    - xcb-util-keysyms                   # [linux]
-    - xcb-util-image                     # [linux]
-    - xcb-util-renderutil                # [linux]
-    # https://github.com/conda-forge/xorg-libx11-feedstock/pull/28
-    - xorg-libx11                        # [linux]
-    # https://github.com/conda-forge/xorg-libxext-feedstock/pull/12
-    - xorg-libxext                       # [linux]
-    # no run_export
-    - xorg-libsm                         # [linux]
-    - xorg-libice                        # [linux]
-    - xorg-xf86vidmodeproto              # [linux]
-  run_constrained:
-    - qt {{ version }}
 
-test:
-  requires:
-    - {{ compiler('cxx') }}
-    - libgl-devel                        # [linux]
-    - libegl-devel                       # [linux]
-    - make                               # [unix]
-    - xcb-util                           # [linux]
-    - xorg-libxdamage                    # [linux]
-    # https://github.com/conda-forge/staged-recipes/pull/22084
-    - xorg-libxxf86vm                    # [linux]
-    # llvm<16 require we manually add libcxx-devel on osx,
-    # see https://github.com/conda-forge/qt-main-feedstock/pull/288#issuecomment-2351649435
-    - libcxx-devel                       # [osx]
-  files:
-    - test/hello.pro
-    - test/main-qtwebengine.cpp
-    - test/main.cpp
-    - test/main.qml
-    - test/qml.qrc
-    - test/qrc_qml.cpp
-    - test/qtwebengine.pro
-    - test/test_qmimedatabase.pro
-    - test/test_qmimedatabase.cpp
-    - xcodebuild
-    - xcrun
+outputs:
+
+  # Everything except shared libraries in lib and plugins
+  - name: qt-main
+    build:
+      detect_binary_files_with_prefix: true
+      run_exports:
+        - {{ pin_subpackage('libqt5', max_pin='x.x') }}
+    requirements:
+      build:
+        - {{ compiler('c') }}
+        - {{ stdlib('c') }}
+        - {{ compiler('cxx') }}
+        # Add openssl to build requirements so that it gets
+        # pinned correctly during the 1 -> 3 migration
+        - openssl                            # [not osx]
+        # libclang is required in order to enable simultaneous x86_64 and
+        # arm64 support for QDoc
+        - libclang                           # [arm64]
+        # Although these should be host-only dependencies, they are needed when
+        # cross-compiling arm64 binaries on x86_64 since llvm-config (host/arm64)
+        # cannot be executed on x86_64 to locate libclang successfully
+        - llvmdev                           # [arm64]
+        # pin llvm<16 because of: https://bugreports.qt.io/browse/PYSIDE-2288
+        - clangdev >=9, <16                 # [arm64]
+        # llvm<16 require we manually add libcxx-devel on osx,
+        # see https://github.com/conda-forge/qt-main-feedstock/pull/288#issuecomment-2351649435
+        - libcxx-devel                       # [osx]
+      host:
+        - libgl-devel                        # [linux]
+        - libegl-devel                       # [linux]
+        - libdrm                             # [linux]
+        # For pkg-config gl, fontconfig + freetype
+        - pthread-stubs                      # [linux]
+        - dbus                               # [linux]
+        - fontconfig                         # [linux]
+        - freetype                           # [linux]
+        - glib
+        - gst-plugins-base  {{ gstreamer }}
+        - gstreamer
+        - pulseaudio-client                  # [linux]
+        - libxml2                            # [linux]
+        - libxkbcommon                       # [linux]
+        - expat                              # [linux]
+        - libevent                           # [linux]
+        - icu
+        - libjpeg-turbo
+        - libpng
+        - nspr                               # [unix]
+        - nss                                # [unix]
+        - libsqlite
+        - mysql-devel                        # [not win]
+        - postgresql                         # [not win]
+        - zlib
+        - libxcb                             # [linux]
+        - openssl                            # [not osx]
+        # For QDoc
+        # http://doc.qt.io/Qt-5/qdoc-guide-clang.html
+        # Only libclang is needed, but needs the full package for detection.
+        - llvm
+        # pin llvm<16 because of: https://bugreports.qt.io/browse/PYSIDE-2288
+        - clangdev >=9, <16
+        # llvm<16 require we manually add libcxx-devel on osx,
+        # see https://github.com/conda-forge/qt-main-feedstock/pull/288#issuecomment-2351649435
+        - libcxx-devel                       # [osx]
+        # Ensure that build and host have the same clang version on osx
+        # otherwise qt6 may be out of sync compared to the pinned compiler
+        # version
+        - libclang     {{ cxx_compiler_version }}     # [osx]
+        - libclang-cpp {{ cxx_compiler_version }}     # [osx]
+        - libclang                                    # [not osx]
+        - libclang-cpp                                # [not osx]
+        - libcups                            # [linux]
+        - zstd
+        - alsa-lib                           # [linux]
+        - krb5
+        - harfbuzz                           # [linux]
+        # The xcb-util packages are necessary to build the Qt xcb plugin.
+        # It was decided to not use CDTs for qt to resolve issues
+        # that may exhibit as segfault due to missing libraries
+        # in some lighter weight linux installations
+        # https://github.com/conda-forge/qt-main-feedstock/issues/32
+        - xcb-util                           # [linux]
+        - xcb-util-wm                        # [linux]
+        - xcb-util-keysyms                   # [linux]
+        - xcb-util-image                     # [linux]
+        - xcb-util-renderutil                # [linux]
+        - xorg-libx11                        # [linux]
+        - xorg-libxext                       # [linux]
+        - xorg-libxdamage                    # [linux]
+        - xorg-libsm                         # [linux]
+        - xorg-libice                        # [linux]
+        # https://github.com/conda-forge/staged-recipes/pull/22084
+        - xorg-libxxf86vm                    # [linux]
+        - xorg-xf86vidmodeproto              # [linux]
+        # qtlocation requires mapbox-gl-native that uses libbost-headers
+        - libboost-headers
+        - {{ pin_subpackage('libqt5', exact=True) }}
+      run:
+        - {{ pin_subpackage('libqt5', exact=True) }}
+        - {{ pin_compatible("nss") }}        # [unix]
+        - {{ pin_compatible("nspr") }}       # [unix]
+        - libxcb                             # [linux]
+        # Adding the following xcb-util run requirements resolves issue
+        # that may exhibit as segfault due to missing libraries
+        # in some lighter weight linux installations
+        # https://github.com/conda-forge/qt-main-feedstock/issues/32
+        - xcb-util-wm                        # [linux]
+        - xcb-util-keysyms                   # [linux]
+        - xcb-util-image                     # [linux]
+        - xcb-util-renderutil                # [linux]
+        # https://github.com/conda-forge/xorg-libx11-feedstock/pull/28
+        - xorg-libx11                        # [linux]
+        # https://github.com/conda-forge/xorg-libxext-feedstock/pull/12
+        - xorg-libxext                       # [linux]
+        # no run_export
+        - xorg-libsm                         # [linux]
+        - xorg-libice                        # [linux]
+        - xorg-xf86vidmodeproto              # [linux]
+      run_constrained:
+        - qt {{ version }}
+    test:
+      requires:
+        - {{ compiler('cxx') }}
+        - libgl-devel                        # [linux]
+        - libegl-devel                       # [linux]
+        - make                               # [unix]
+        - xcb-util                           # [linux]
+        - xorg-libxdamage                    # [linux]
+        # https://github.com/conda-forge/staged-recipes/pull/22084
+        - xorg-libxxf86vm                    # [linux]
+        # llvm<16 require we manually add libcxx-devel on osx,
+        # see https://github.com/conda-forge/qt-main-feedstock/pull/288#issuecomment-2351649435
+        - libcxx-devel                       # [osx]
+      files:
+        - test/hello.pro
+        - test/main-qtwebengine.cpp
+        - test/main.cpp
+        - test/main.qml
+        - test/qml.qrc
+        - test/qrc_qml.cpp
+        - test/qtwebengine.pro
+        - test/test_qmimedatabase.pro
+        - test/test_qmimedatabase.cpp
+        - xcodebuild
+        - xcrun
+
+  # Only what's needed for run_exports downstream
+  - name: libqt5
+    build:
+      detect_binary_files_with_prefix: true
+      run_exports:
+        - {{ pin_subpackage('libqt5', max_pin='x.x') }}
+    requirements:
+      build:
+        - {{ compiler('c') }}
+        - {{ stdlib('c') }}
+        - {{ compiler('cxx') }}
+        # Add openssl to build requirements so that it gets
+        # pinned correctly during the 1 -> 3 migration
+        - openssl                            # [not osx]
+        # libclang is required in order to enable simultaneous x86_64 and
+        # arm64 support for QDoc
+        - libclang                           # [arm64]
+        # Although these should be host-only dependencies, they are needed when
+        # cross-compiling arm64 binaries on x86_64 since llvm-config (host/arm64)
+        # cannot be executed on x86_64 to locate libclang successfully
+        - llvmdev                           # [arm64]
+        # pin llvm<16 because of: https://bugreports.qt.io/browse/PYSIDE-2288
+        - clangdev >=9, <16                 # [arm64]
+        # llvm<16 require we manually add libcxx-devel on osx,
+        # see https://github.com/conda-forge/qt-main-feedstock/pull/288#issuecomment-2351649435
+        - libcxx-devel                       # [osx]
+      host:
+        - libgl-devel                        # [linux]
+        - libegl-devel                       # [linux]
+        - libdrm                             # [linux]
+        # For pkg-config gl, fontconfig + freetype
+        - pthread-stubs                      # [linux]
+        - dbus                               # [linux]
+        - fontconfig                         # [linux]
+        - freetype                           # [linux]
+        - glib
+        - gst-plugins-base  {{ gstreamer }}
+        - gstreamer
+        - pulseaudio-client                  # [linux]
+        - libxml2                            # [linux]
+        - libxkbcommon                       # [linux]
+        - expat                              # [linux]
+        - libevent                           # [linux]
+        - icu
+        - libjpeg-turbo
+        - libpng
+        - nspr                               # [unix]
+        - nss                                # [unix]
+        - libsqlite
+        - mysql-devel                        # [not win]
+        - postgresql                         # [not win]
+        - zlib
+        - libxcb                             # [linux]
+        - openssl                            # [not osx]
+        # For QDoc
+        # http://doc.qt.io/Qt-5/qdoc-guide-clang.html
+        # Only libclang is needed, but needs the full package for detection.
+        - llvm
+        # pin llvm<16 because of: https://bugreports.qt.io/browse/PYSIDE-2288
+        - clangdev >=9, <16
+        # llvm<16 require we manually add libcxx-devel on osx,
+        # see https://github.com/conda-forge/qt-main-feedstock/pull/288#issuecomment-2351649435
+        - libcxx-devel                       # [osx]
+        # Ensure that build and host have the same clang version on osx
+        # otherwise qt6 may be out of sync compared to the pinned compiler
+        # version
+        - libclang     {{ cxx_compiler_version }}     # [osx]
+        - libclang-cpp {{ cxx_compiler_version }}     # [osx]
+        - libclang                                    # [not osx]
+        - libclang-cpp                                # [not osx]
+        - libcups                            # [linux]
+        - zstd
+        - alsa-lib                           # [linux]
+        - krb5
+        - harfbuzz                           # [linux]
+        # The xcb-util packages are necessary to build the Qt xcb plugin.
+        # It was decided to not use CDTs for qt to resolve issues
+        # that may exhibit as segfault due to missing libraries
+        # in some lighter weight linux installations
+        # https://github.com/conda-forge/qt-main-feedstock/issues/32
+        - xcb-util                           # [linux]
+        - xcb-util-wm                        # [linux]
+        - xcb-util-keysyms                   # [linux]
+        - xcb-util-image                     # [linux]
+        - xcb-util-renderutil                # [linux]
+        - xorg-libx11                        # [linux]
+        - xorg-libxext                       # [linux]
+        - xorg-libxdamage                    # [linux]
+        - xorg-libsm                         # [linux]
+        - xorg-libice                        # [linux]
+        # https://github.com/conda-forge/staged-recipes/pull/22084
+        - xorg-libxxf86vm                    # [linux]
+        - xorg-xf86vidmodeproto              # [linux]
+        # qtlocation requires mapbox-gl-native that uses libbost-headers
+        - libboost-headers
+      run:
+        - {{ pin_compatible("nss") }}        # [unix]
+        - {{ pin_compatible("nspr") }}       # [unix]
+        - libxcb                             # [linux]
+        # Adding the following xcb-util run requirements resolves issue
+        # that may exhibit as segfault due to missing libraries
+        # in some lighter weight linux installations
+        # https://github.com/conda-forge/qt-main-feedstock/issues/32
+        - xcb-util-wm                        # [linux]
+        - xcb-util-keysyms                   # [linux]
+        - xcb-util-image                     # [linux]
+        - xcb-util-renderutil                # [linux]
+        # https://github.com/conda-forge/xorg-libx11-feedstock/pull/28
+        - xorg-libx11                        # [linux]
+        # https://github.com/conda-forge/xorg-libxext-feedstock/pull/12
+        - xorg-libxext                       # [linux]
+        # no run_export
+        - xorg-libsm                         # [linux]
+        - xorg-libice                        # [linux]
+        - xorg-xf86vidmodeproto              # [linux]
+      run_constrained:
+        - qt {{ version }}
 
 about:
   home: https://qt.io
@@ -240,6 +458,7 @@ about:
   dev_url: https://github.com/qt
 
 extra:
+  feedstock-name: qt-main
   recipe-maintainers:
     - andfoy
     - ccordoba12

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -189,6 +189,14 @@ outputs:
       detect_binary_files_with_prefix: true
       run_exports:
         - {{ pin_subpackage('libqt5', max_pin='x.x') }}
+    files:
+      include:
+        - {{ library }}**
+      exclude:
+        - {{ library }}bin/*.dll         # [win]
+        - {{ library }}lib/lib*.*.dylib  # [osx]
+        - {{ library }}lib/lib*.so.*     # [linux]
+        - {{ library }}plugins/**
     requirements:
       build:
         - {{ compiler('c') }}
@@ -334,6 +342,12 @@ outputs:
       detect_binary_files_with_prefix: true
       run_exports:
         - {{ pin_subpackage('libqt5', max_pin='x.x') }}
+    files:
+      include:
+        - {{ library }}bin/*.dll         # [win]
+        - {{ library }}lib/lib*.*.dylib  # [osx]
+        - {{ library }}lib/lib*.so.*     # [linux]
+        - {{ library }}plugins/**
     requirements:
       build:
         - {{ compiler('c') }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -67,8 +67,6 @@ source:
 build:
   number: 27
   detect_binary_files_with_prefix: true
-  run_exports:
-    - {{ pin_subpackage('qt-main', max_pin='x.x') }}
   missing_dso_whitelist:  # [osx]
     - /usr/lib/libbsm.0.dylib  # [osx]
     - /usr/lib/libcups.2.dylib  # [osx]
@@ -191,12 +189,12 @@ outputs:
         - {{ pin_subpackage('libqt5', max_pin='x.x') }}
     files:
       include:
-        - {{ library }}**
+        - "{{ library }}**/*"
       exclude:
         - {{ library }}bin/*.dll         # [win]
         - {{ library }}lib/lib*.*.dylib  # [osx]
         - {{ library }}lib/lib*.so.*     # [linux]
-        - {{ library }}plugins/**
+        - "{{ library }}plugins/**"
     requirements:
       build:
         - {{ compiler('c') }}
@@ -347,7 +345,7 @@ outputs:
         - {{ library }}bin/*.dll         # [win]
         - {{ library }}lib/lib*.*.dylib  # [osx]
         - {{ library }}lib/lib*.so.*     # [linux]
-        - {{ library }}plugins/**
+        - "{{ library }}plugins/**/*"
     requirements:
       build:
         - {{ compiler('c') }}


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->
Closes #42

<!--
Please add any other relevant info below:
-->

This PR separates the shared and dynamically loaded libraries in /lib and /plugins into a separate output from qt-main; this new output is called libqt5.

The purpose of creating this new output is to reduce the size of run exports for downstream packages which link to qt.

The size of the new libqt5 package is 31MB/100MB (compressed/uncompressed) which is about half the size of the current qt-main package (61MB/254MB).

As you can see from the diff, the build script is unchanged.

There is one change to the top-level build/host requirements: The libclang version is now manually pinned to 15 via the conda_build_config.yaml. This is because using pin_compatible in the outputs section causes an error in conda-build as noted in https://github.com/conda-forge/qt-main-feedstock/pull/223#issuecomment-1876139556.

A new output section which splits the artifacts and dependencies using glob expressions.

Runtime dependencies on libraries who now have run_exports upstream were removed.

For testing, I have compared the artifacts using git, to identify added/missing files.

* [ ] linux64 - No significant difference; some pyc files are not packaged.
* [ ] osx64
* [ ] win64

https://doc.qt.io/qt-6/deployment-plugins.html
