### PR TITLE
No gstreamer in qt 6.7.1

### DIFF
--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -30,8 +30,6 @@ freetype:
 - '2'
 glib:
 - '2'
-gstreamer:
-- '1.24'
 harfbuzz:
 - '8'
 icu:

--- a/.ci_support/linux_aarch64_.yaml
+++ b/.ci_support/linux_aarch64_.yaml
@@ -34,8 +34,6 @@ freetype:
 - '2'
 glib:
 - '2'
-gstreamer:
-- '1.24'
 harfbuzz:
 - '8'
 icu:

--- a/.ci_support/osx_64_.yaml
+++ b/.ci_support/osx_64_.yaml
@@ -22,8 +22,6 @@ cxx_compiler_version:
 - '16'
 glib:
 - '2'
-gstreamer:
-- '1.24'
 harfbuzz:
 - '8'
 icu:

--- a/.ci_support/osx_arm64_.yaml
+++ b/.ci_support/osx_arm64_.yaml
@@ -22,8 +22,6 @@ cxx_compiler_version:
 - '16'
 glib:
 - '2'
-gstreamer:
-- '1.24'
 harfbuzz:
 - '8'
 icu:

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @Tobias-Fischer @andfoy @ccordoba12 @duncanmmacleod @gillins @jschueller @matthiasdiener @mingwandroid @msarahan @ocefpaf @stuarteberg
+* @Tobias-Fischer @andfoy @ccordoba12 @gillins @jschueller @matthiasdiener @mingwandroid @msarahan @ocefpaf @stuarteberg

--- a/README.md
+++ b/README.md
@@ -201,7 +201,6 @@ Feedstock Maintainers
 * [@Tobias-Fischer](https://github.com/Tobias-Fischer/)
 * [@andfoy](https://github.com/andfoy/)
 * [@ccordoba12](https://github.com/ccordoba12/)
-* [@duncanmmacleod](https://github.com/duncanmmacleod/)
 * [@gillins](https://github.com/gillins/)
 * [@jschueller](https://github.com/jschueller/)
 * [@matthiasdiener](https://github.com/matthiasdiener/)

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -34,6 +34,7 @@ if [[ "$CONDA_BUILD_CROSS_COMPILATION" = "1" ]]; then
       -DCMAKE_INSTALL_RPATH:STRING=${BUILD_PREFIX}/lib \
       -DCMAKE_UNITY_BUILD=ON -DCMAKE_UNITY_BUILD_BATCH_SIZE=32 \
       -DFEATURE_system_sqlite=ON \
+      -DFEATURE_gstreamer=OFF \
       -DFEATURE_framework=OFF \
       -DFEATURE_gssapi=OFF \
       -DQT_BUILD_SUBMODULES="qtbase;qtshadertools;qttools" \
@@ -82,11 +83,11 @@ cmake -LAH -G "Ninja" ${CMAKE_ARGS} \
   -DINSTALL_MKSPECSDIR=lib/qt6/mkspecs \
   -DINSTALL_EXAMPLESDIR=share/doc/qt6/examples \
   -DFEATURE_system_sqlite=ON \
+  -DFEATURE_gstreamer=OFF \
   -DFEATURE_framework=OFF \
   -DFEATURE_linux_v4l=OFF \
   -DFEATURE_gssapi=OFF \
   -DFEATURE_enable_new_dtags=OFF \
-  -DFEATURE_gstreamer_gl=OFF \
   -DFEATURE_openssl_linked=ON \
   -DFEATURE_quick3d_assimp=OFF \
   -DQT_BUILD_SUBMODULES="qtbase;\

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,7 +24,7 @@ source:
     folder: opengl32sw                                                                                            # [win64]
 
 build:
-  number: 0
+  number: 1
   detect_binary_files_with_prefix: true
   run_exports:
     - {{ pin_subpackage('qt6-main', max_pin='x.x') }}
@@ -85,8 +85,6 @@ requirements:
     - freetype                          # [(build_platform != target_platform) and linux]
     - harfbuzz                          # [build_platform != target_platform]
     - glib                              # [build_platform != target_platform]
-    - gst-plugins-base {{ gstreamer }}  # [build_platform != target_platform]
-    - gstreamer                         # [build_platform != target_platform]
     - pulseaudio                        # [(build_platform != target_platform) and linux]
     - libxml2                           # [(build_platform != target_platform) and linux]
     - libxkbcommon                      # [(build_platform != target_platform) and linux]
@@ -132,9 +130,6 @@ requirements:
     - freetype                           # [linux]
     - harfbuzz
     - glib
-    - gst-plugins-base  {{ gstreamer }}  # [unix]
-    # gstreamer plugin not supported on win32: https://bugreports.qt.io/browse/QTBUG-107073
-    - gstreamer                          # [unix]
     - pulseaudio                         # [linux]
     - libxml2                            # [linux]
     - libxkbcommon                       # [linux]


### PR DESCRIPTION
Personally, i'm worried about the build times in:
https://github.com/conda-forge/qt-main-feedstock/pull/256

Lets see how they stack up.

https://github.com/conda-forge/staged-recipes/pull/25992

Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
