### PR TITLE
Fix mutimedia and qtquick3d qt6

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @Tobias-Fischer @andfoy @ccordoba12 @duncanmmacleod @gillins @jschueller @matthiasdiener @mingwandroid @msarahan @ocefpaf @stuarteberg
+* @Tobias-Fischer @andfoy @ccordoba12 @gillins @jschueller @matthiasdiener @mingwandroid @msarahan @ocefpaf @stuarteberg

--- a/README.md
+++ b/README.md
@@ -201,7 +201,6 @@ Feedstock Maintainers
 * [@Tobias-Fischer](https://github.com/Tobias-Fischer/)
 * [@andfoy](https://github.com/andfoy/)
 * [@ccordoba12](https://github.com/ccordoba12/)
-* [@duncanmmacleod](https://github.com/duncanmmacleod/)
 * [@gillins](https://github.com/gillins/)
 * [@jschueller](https://github.com/jschueller/)
 * [@matthiasdiener](https://github.com/matthiasdiener/)

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -5,6 +5,10 @@ mkdir %LIBRARY_PREFIX%\lib\cmake\tiff\include
 set "MODS=qtbase"
 set "MODS=%MODS%;qtdeclarative"
 set "MODS=%MODS%;qtimageformats"
+:REM qt-multimedia will be a separate pacakge after 6.7.1
+IF %PKG_VERSION%=="6.7.1" (
+   set "MODS=%MODS%;qtmultimedia"
+)
 set "MODS=%MODS%;qtshadertools"
 set "MODS=%MODS%;qtsvg"
 set "MODS=%MODS%;qttools"
@@ -46,6 +50,7 @@ cmake -LAH -G "Ninja" ^
     -DFEATURE_system_sqlite=ON ^
     -DFEATURE_quick3d_assimp=OFF ^
     -DFEATURE_vulkan=ON ^
+    -DQT_MEDIA_BACKEND=ffmpeg ^
     -DINPUT_opengl=%OPENGLVER% ^
     -DQT_BUILD_SUBMODULES="%MODS%" ^
     -B build .

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -9,6 +9,7 @@ set "MODS=%MODS%;qtimageformats"
 IF %PKG_VERSION%=="6.7.1" (
    set "MODS=%MODS%;qtmultimedia"
 )
+set "MODS=%MODS%;qtquick3d"
 set "MODS=%MODS%;qtshadertools"
 set "MODS=%MODS%;qtsvg"
 set "MODS=%MODS%;qttools"

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -76,6 +76,7 @@ qtshadertools;\
 qtsvg;\
 qttools;\
 qttranslations;\
+qtquick3d;\
 qt5compat;\
 qtwebchannel;\
 qtwebsockets"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -249,6 +249,7 @@ test:
                       "Test",
                       "Qml",
                       "Quick",
+                      "Quick3D",
                       "Widgets",
                       "Xml"] %}
     {% for each_qt_lib in qt_libs %}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,7 +24,7 @@ source:
     folder: opengl32sw                                                                                            # [win64]
 
 build:
-  number: 1
+  number: 2
   detect_binary_files_with_prefix: true
   run_exports:
     - {{ pin_subpackage('qt6-main', max_pin='x.x') }}


### PR DESCRIPTION
I didn't realize that I accidentally removed qtmultimedia package from being built at all on windows (even if minimally) in https://github.com/conda-forge/qt-main-feedstock/pull/256/commits/25ece9100f743c6bd57539fb8f67b1e1ebaa422f


This ends up not building `Qt6Quick3D` so i added that module as well.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
