### PR TITLE
Pass -DQT_REQUIRE_HOST_PATH_CHECK=OFF in cross-compiled builds

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -46,7 +46,7 @@ if [[ "$CONDA_BUILD_CROSS_COMPILATION" = "1" ]]; then
     cmake --build build_native --target install
     mv _hidden $BUILD_PREFIX/${HOST}
   )
-  CMAKE_ARGS="${CMAKE_ARGS} -DQT_HOST_PATH=${BUILD_PREFIX} -DQT_FORCE_BUILD_TOOLS=ON -DBUILD_WITH_PCH=OFF"
+  CMAKE_ARGS="${CMAKE_ARGS} -DQT_HOST_PATH=${BUILD_PREFIX} -DQT_FORCE_BUILD_TOOLS=ON -DQT_REQUIRE_HOST_PATH_CHECK=OFF -DBUILD_WITH_PCH=OFF"
 
   # Error: unknown architecture `nocona' on linux-aarch64
   if test "${target_platform}" = "linux-aarch64"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,7 +21,7 @@ source:
     folder: opengl32sw                                                                                            # [win64]
 
 build:
-  number: 1
+  number: 2
   detect_binary_files_with_prefix: true
   run_exports:
     - {{ pin_subpackage('qt6-main', max_pin='x.x') }}


### PR DESCRIPTION
Fix https://github.com/conda-forge/qt-main-feedstock/issues/273 . Without this fix, native compilation failed on `find_package(Qt6 REQUIRED)` if a cross-compiled qt6-main was used.

Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
