### PR TITLE
Remove qt5.15.8 from abi_migration_branches

### DIFF
--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -8,7 +8,6 @@ azure:
 bot:
   abi_migration_branches:
   - qt6
-  - qt5.15.8
 build_platform:
   linux_aarch64: linux_aarch64
   linux_ppc64le: linux_ppc64le


### PR DESCRIPTION
See discussion in https://github.com/conda-forge/qt-main-feedstock/pull/309#issuecomment-2512150568 . I wanted to do this together with the libboost 1.86 migration, but I realized later that that was already done for the main branch. As this just changes the `conda-forge.yml`, there is no need for a  new build.

Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
