### PR TITLE
Rebuild qt6 for libxcb 1.17

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,7 +21,7 @@ source:
     folder: opengl32sw                                                                                            # [win64]
 
 build:
-  number: 1
+  number: 2
   # bumping qt version requires a 2-staged build as cross builds require the native package with the same version
   # skip: true  # [build_platform != target_platform]
   detect_binary_files_with_prefix: true
@@ -103,6 +103,8 @@ requirements:
     - pcre2
     - zlib
     - libxcb                             # [linux]
+    # libxcb 1.16 has very strict pins and we want to avoid it
+    - libxcb >=1.17                      # [linux]
     - libdrm                             # [linux]
     - openssl
     # For QDoc
@@ -147,7 +149,7 @@ requirements:
     # https://github.com/conda-forge/staged-recipes/pull/22084
     - xorg-libxxf86vm                    # [linux]
     - xorg-libxtst                       # [linux]
-    - xorg-xf86vidmodeproto              # [linux]
+    - xorg-xorgproto                     # [linux]
   run:
     - libxcb                             # [linux]
     # Adding the following xcb-util run requirements resolves issue

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -103,8 +103,6 @@ requirements:
     - pcre2
     - zlib
     - libxcb                             # [linux]
-    # libxcb 1.16 has very strict pins and we want to avoid it
-    - libxcb >=1.17                      # [linux]
     - libdrm                             # [linux]
     - openssl
     # For QDoc


### PR DESCRIPTION
These pins are very strict and a little old.
see https://conda-metadata-app.streamlit.app/?q=conda-forge%2Flinux-64%2Fqt6-main-6.8.1-h588cce1_1.conda

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
