### PR TITLE
Add a patch to ensure that find_package(Qt6 REQUIRED) works out of the box also in cross-compiled builds

### DIFF
--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -53,7 +53,7 @@ libxml2:
 openssl:
 - '3'
 pcre2:
-- '10.44'
+- '10.45'
 postgresql:
 - '17'
 target_platform:

--- a/.ci_support/linux_aarch64_.yaml
+++ b/.ci_support/linux_aarch64_.yaml
@@ -53,7 +53,7 @@ libxml2:
 openssl:
 - '3'
 pcre2:
-- '10.44'
+- '10.45'
 postgresql:
 - '17'
 target_platform:

--- a/.ci_support/osx_64_.yaml
+++ b/.ci_support/osx_64_.yaml
@@ -43,7 +43,7 @@ macos_machine:
 openssl:
 - '3'
 pcre2:
-- '10.44'
+- '10.45'
 postgresql:
 - '17'
 target_platform:

--- a/.ci_support/osx_arm64_.yaml
+++ b/.ci_support/osx_arm64_.yaml
@@ -43,7 +43,7 @@ macos_machine:
 openssl:
 - '3'
 pcre2:
-- '10.44'
+- '10.45'
 postgresql:
 - '17'
 target_platform:

--- a/.ci_support/win_64_.yaml
+++ b/.ci_support/win_64_.yaml
@@ -31,7 +31,7 @@ libwebp:
 openssl:
 - '3'
 pcre2:
-- '10.44'
+- '10.45'
 target_platform:
 - win-64
 zlib:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,12 +19,15 @@ source:
       # https://bugreports.qt.io/browse/QTBUG-135279
       - patches/0008-qtdeclarative-codesign.patch
 
+      # Ensure that cross-compiled builds and native builds generated the same cmake config files
+      - patches/0020-remove-qt-host-path-check-in-cross-compiled-builds.patch
+
   - url: https://download.qt.io/development_releases/prebuilt/llvmpipe/windows/opengl32sw-64-mesa_12_0_rc2.7z     # [win64]
     sha256: 2a0d2f92c60e0962ef5f6039d3793424c6f39e49ba27ac04a5b21ca4ae012e15                                      # [win64]
     folder: opengl32sw                                                                                            # [win64]
 
 build:
-  number: 2
+  number: 3
   # bumping qt version requires a 2-staged build as cross builds require the native package with the same version
   # skip: true  # [build_platform != target_platform]
   detect_binary_files_with_prefix: true

--- a/recipe/patches/0020-remove-qt-host-path-check-in-cross-compiled-builds.patch
+++ b/recipe/patches/0020-remove-qt-host-path-check-in-cross-compiled-builds.patch
@@ -1,0 +1,22 @@
+From 16167eb8f28f49b6fede5dbdb7d4e41fcac2fa07 Mon Sep 17 00:00:00 2001
+From: Silvio Traversaro <silvio@traversaro.it>
+Date: Wed, 14 May 2025 15:10:58 +0200
+Subject: [PATCH] Remove need to set QT_HOST_PATH for cross-compiled builds
+
+---
+ cmake/QtConfigDependencies.cmake.in | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/qtbase/cmake/QtConfigDependencies.cmake.in b/cmake/QtConfigDependencies.cmake.in
+index e68e2954f9d..e64b663bb36 100644
+--- a/qtbase/cmake/QtConfigDependencies.cmake.in
++++ b/qtbase/cmake/QtConfigDependencies.cmake.in
+@@ -8,7 +8,7 @@ if(DEFINED QT_REQUIRE_HOST_PATH_CHECK)
+ elseif(DEFINED ENV{QT_REQUIRE_HOST_PATH_CHECK})
+     set(__qt_platform_requires_host_info_package "$ENV{QT_REQUIRE_HOST_PATH_CHECK}")
+ else()
+-    set(__qt_platform_requires_host_info_package "@platform_requires_host_info_package@")
++    set(__qt_platform_requires_host_info_package "FALSE")
+ endif()
+ set(__qt_platform_initial_qt_host_path "@qt_host_path_absolute@")
+ set(__qt_platform_initial_qt_host_path_cmake_dir "@qt_host_path_cmake_dir_absolute@")

--- a/recipe/run_test.sh
+++ b/recipe/run_test.sh
@@ -7,8 +7,6 @@ set -ex
 # See https://github.com/conda-forge/qt-main-feedstock/issues/99
 test -f ${PREFIX}/bin/qt6.conf
 
-test "${HOST}" = "aarch64-conda-linux-gnu" && exit 0
-
 ls
 cd test
 cmake .


### PR DESCRIPTION
By default, `find_package(Qt6 REQUIRED)` does not work (even for native downstream builds) for qt6-main packages that have been built in a cross-compilation (in particular `osx-arm64` and `linux-aarch64` as of May 2025). This happens as by default qt assumes that cross-compiled builds are consumed by a cross-compiler, but this is is not true in general for conda-forge (especially for `osx-arm64`, where most non-CI usage is not in cross-compilation).

This PR fixes this by patching qt to ensure that the CMake config files generated by native builds and by cross-compiled builds are the same, as it usually happens for conda-forge packages.

The fix is validated by the existing tests, that before were skipped for linux-aarch64 via a `test "${HOST}" = "aarch64-conda-linux-gnu" && exit 0` command in `run_tests.sh`. This should ensure that the fix actually works.

Fix https://github.com/conda-forge/qt-main-feedstock/issues/333 .
Fix https://github.com/conda-forge/qt-main-feedstock/issues/273 .


Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
