### PR TITLE
Do not link against AGL framework on macOS. (Qt6.8)

### DIFF
--- a/.ci_support/win_64_.yaml
+++ b/.ci_support/win_64_.yaml
@@ -1,5 +1,5 @@
 c_compiler:
-- vs2019
+- vs2022
 c_stdlib:
 - vs
 channel_sources:
@@ -9,7 +9,7 @@ channel_targets:
 curl:
 - '8'
 cxx_compiler:
-- vs2019
+- vs2022
 glib:
 - '2'
 harfbuzz:

--- a/build-locally.py
+++ b/build-locally.py
@@ -106,9 +106,7 @@ def main(args=None):
         action="store_true",
         help="Setup debug environment using `conda debug`",
     )
-    p.add_argument(
-        "--output-id", help="If running debug, specify the output to setup."
-    )
+    p.add_argument("--output-id", help="If running debug, specify the output to setup.")
 
     ns = p.parse_args(args=args)
     verify_config(ns)
@@ -124,9 +122,7 @@ def main(args=None):
         elif ns.config.startswith("win"):
             run_win_build(ns)
     finally:
-        recipe_license_file = os.path.join(
-            "recipe", "recipe-scripts-license.txt"
-        )
+        recipe_license_file = os.path.join("recipe", "recipe-scripts-license.txt")
         if os.path.exists(recipe_license_file):
             os.remove(recipe_license_file)
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,12 +22,15 @@ source:
       # Ensure that cross-compiled builds and native builds generated the same cmake config files
       - patches/0020-remove-qt-host-path-check-in-cross-compiled-builds.patch
 
+      # remove AGL framework as it is no longer in macOS 26 and is unused
+      - patches/0025-macos-no-agl-framework.patch
+
   - url: https://download.qt.io/development_releases/prebuilt/llvmpipe/windows/opengl32sw-64-mesa_12_0_rc2.7z     # [win64]
     sha256: 2a0d2f92c60e0962ef5f6039d3793424c6f39e49ba27ac04a5b21ca4ae012e15                                      # [win64]
     folder: opengl32sw                                                                                            # [win64]
 
 build:
-  number: 3
+  number: 4
   # bumping qt version requires a 2-staged build as cross builds require the native package with the same version
   # skip: true  # [build_platform != target_platform]
   detect_binary_files_with_prefix: true

--- a/recipe/patches/0025-macos-no-agl-framework.patch
+++ b/recipe/patches/0025-macos-no-agl-framework.patch
@@ -1,0 +1,60 @@
+From cdb33c3d5621ce035ad6950c8e2268fe94b73de5 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Tor=20Arne=20Vestb=C3=B8?= <tor.arne.vestbo@qt.io>
+Date: Tue, 10 Jun 2025 06:46:30 -0700
+Subject: [PATCH] macOS: Remove linkage to AGL framework
+
+It's no longer available on macOS 26, and we don't use it anymore
+anyways.
+
+Pick-to: 6.10 6.9 6.8 6.5
+Change-Id: Ia1d0e37dda177f333646e598e517f4af20215dad
+Reviewed-by: Alexandru Croitor <alexandru.croitor@qt.io>
+---
+ cmake/FindWrapOpenGL.cmake | 9 ---------
+ mkspecs/common/mac.conf    | 5 ++---
+ 2 files changed, 2 insertions(+), 12 deletions(-)
+
+diff --git a/qtbase/cmake/FindWrapOpenGL.cmake b/qtbase/cmake/FindWrapOpenGL.cmake
+index 7295a159caf6..fe73ab782118 100644
+--- a/qtbase/cmake/FindWrapOpenGL.cmake
++++ b/qtbase/cmake/FindWrapOpenGL.cmake
+@@ -37,16 +37,7 @@ if (OpenGL_FOUND)
+             set(__opengl_fw_path "-framework OpenGL")
+         endif()
+
+-        find_library(WrapOpenGL_AGL NAMES AGL)
+-        if(WrapOpenGL_AGL)
+-            set(__opengl_agl_fw_path "${WrapOpenGL_AGL}")
+-        endif()
+-        if(NOT __opengl_agl_fw_path)
+-            set(__opengl_agl_fw_path "-framework AGL")
+-        endif()
+-
+         target_link_libraries(WrapOpenGL::WrapOpenGL INTERFACE ${__opengl_fw_path})
+-        target_link_libraries(WrapOpenGL::WrapOpenGL INTERFACE ${__opengl_agl_fw_path})
+     else()
+         target_link_libraries(WrapOpenGL::WrapOpenGL INTERFACE OpenGL::GL)
+     endif()
+diff --git a/mkspecs/common/mac.conf b/mkspecs/common/mac.conf
+index 61bea952b220..9ba38d9949d6 100644
+--- a/qtbase/mkspecs/common/mac.conf
++++ b/qtbase/mkspecs/common/mac.conf
+@@ -18,8 +18,7 @@ QMAKE_LIBDIR            =
+
+ # sdk.prf will prefix the proper SDK sysroot
+ QMAKE_INCDIR_OPENGL     = \
+-    /System/Library/Frameworks/OpenGL.framework/Headers \
+-    /System/Library/Frameworks/AGL.framework/Headers/
++    /System/Library/Frameworks/OpenGL.framework/Headers
+
+ QMAKE_FIX_RPATH         = install_name_tool -id
+
+@@ -30,7 +29,7 @@ QMAKE_LFLAGS_REL_RPATH  =
+ QMAKE_REL_RPATH_BASE    = @loader_path
+
+ QMAKE_LIBS_DYNLOAD      =
+-QMAKE_LIBS_OPENGL       = -framework OpenGL -framework AGL
++QMAKE_LIBS_OPENGL       = -framework OpenGL
+ QMAKE_LIBS_THREAD       =
+
+ QMAKE_INCDIR_WAYLAND    =


### PR DESCRIPTION
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

macOS 26 no longer provides the AGL framework, which was a support framework for Carbon applications. As Carbon is no longer supported, neither is AGL.

The AGL framework is unused and therefore safe to remove references to.