### PR TITLE
Enable Vulkan support on macOS

### DIFF
--- a/.azure-pipelines/azure-pipelines-osx.yml
+++ b/.azure-pipelines/azure-pipelines-osx.yml
@@ -13,6 +13,9 @@ jobs:
         UPLOAD_PACKAGES: 'True'
         VMIMAGE: macOS-15
         build_workspace_dir: ~/miniforge3/conda-bld
+        free_disk_space: quick
+        pagefile_size: 0
+        resize_partitions: false
         store_build_artifacts: false
         tools_install_dir: ~/miniforge3
       osx_arm64_:
@@ -20,6 +23,9 @@ jobs:
         UPLOAD_PACKAGES: 'True'
         VMIMAGE: macOS-15-arm64
         build_workspace_dir: ~/miniforge3/conda-bld
+        free_disk_space: quick
+        pagefile_size: 0
+        resize_partitions: false
         store_build_artifacts: false
         tools_install_dir: ~/miniforge3
   timeoutInMinutes: 360
@@ -28,15 +34,20 @@ jobs:
   steps:
   # TODO: Fast finish on azure pipelines?
   - script: |
-      export MINIFORGE_HOME=$(tools_install_dir)
-      export CONDA_BLD_PATH=$(build_workspace_dir)
+      .scripts/free_disk_space.sh "$(free_disk_space)"
+    env:
+      OS: macos
+    displayName: Manage disk space
+  - script: |
       export CI=azure
+      export CONDA_BLD_PATH=$(build_workspace_dir)
+      export FEEDSTOCK_NAME=$(basename ${BUILD_REPOSITORY_NAME})
+      export GIT_BRANCH=$BUILD_SOURCEBRANCHNAME
+      export MINIFORGE_HOME=$(tools_install_dir)
+      export OSX_FORCE_SDK_DOWNLOAD="1"
       export flow_run_id=azure_$(Build.BuildNumber).$(System.JobAttempt)
       export remote_url=$(Build.Repository.Uri)
       export sha=$(Build.SourceVersion)
-      export OSX_FORCE_SDK_DOWNLOAD="1"
-      export GIT_BRANCH=$BUILD_SOURCEBRANCHNAME
-      export FEEDSTOCK_NAME=$(basename ${BUILD_REPOSITORY_NAME})
       if [[ "${BUILD_REASON:-}" == "PullRequest" ]]; then
         export IS_PR_BUILD="True"
       else

--- a/.azure-pipelines/azure-pipelines-win.yml
+++ b/.azure-pipelines/azure-pipelines-win.yml
@@ -12,6 +12,9 @@ jobs:
         CONFIG: win_64_
         UPLOAD_PACKAGES: 'True'
         build_workspace_dir: C:\bld\
+        free_disk_space: quick
+        pagefile_size: 0
+        resize_partitions: false
         store_build_artifacts: false
         tools_install_dir: D:\Miniforge
   timeoutInMinutes: 360
@@ -19,21 +22,25 @@ jobs:
     UPLOAD_TEMP: D:\\tmp
 
   steps:
-
+    - bash: |
+        .scripts/free_disk_space.sh "$(free_disk_space)"
+      displayName: Manage disk space
+      env:
+        OS: windows
     - script: |
         call ".scripts\run_win_build.bat"
       displayName: Run Windows build
       env:
-        MINIFORGE_HOME: $(tools_install_dir)
-        CONDA_BLD_PATH: $(build_workspace_dir)
-        PYTHONUNBUFFERED: 1
-        CONFIG: $(CONFIG)
         CI: azure
+        CONFIG: $(CONFIG)
+        CONDA_BLD_PATH: $(build_workspace_dir)
+        MINIFORGE_HOME: $(tools_install_dir)
+        PYTHONUNBUFFERED: 1
+        UPLOAD_PACKAGES: $(UPLOAD_PACKAGES)
+        UPLOAD_TEMP: $(UPLOAD_TEMP)
         flow_run_id: azure_$(Build.BuildNumber).$(System.JobAttempt)
         remote_url: $(Build.Repository.Uri)
         sha: $(Build.SourceVersion)
-        UPLOAD_PACKAGES: $(UPLOAD_PACKAGES)
-        UPLOAD_TEMP: $(UPLOAD_TEMP)
         BINSTAR_TOKEN: $(BINSTAR_TOKEN)
         FEEDSTOCK_TOKEN: $(FEEDSTOCK_TOKEN)
         STAGING_BINSTAR_TOKEN: $(STAGING_BINSTAR_TOKEN)

--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -23,7 +23,7 @@ cxx_compiler_version:
 dbus:
 - '1'
 docker_image:
-- quay.io/condaforge/linux-anvil-x86_64:alma9
+- quay.io/condaforge/linux-anvil-x86_64:alma10
 fontconfig:
 - '2'
 freetype:

--- a/.ci_support/linux_aarch64_.yaml
+++ b/.ci_support/linux_aarch64_.yaml
@@ -23,7 +23,7 @@ cxx_compiler_version:
 dbus:
 - '1'
 docker_image:
-- quay.io/condaforge/linux-anvil-aarch64:alma9
+- quay.io/condaforge/linux-anvil-aarch64:alma10
 fontconfig:
 - '2'
 freetype:

--- a/.github/workflows/conda-build.yml
+++ b/.github/workflows/conda-build.yml
@@ -23,89 +23,101 @@ jobs:
       matrix:
         include:
           - CONFIG: linux_64_
+            DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma10
             STORE_BUILD_ARTIFACTS: False
             UPLOAD_PACKAGES: True
+            build_workspace_dir: build_artifacts
+            docker_run_args:
+            free_disk_space: skip
             os: ubuntu
+            pagefile_size: 0
+            resize_partitions: False
             runs_on: ['ubuntu-latest']
-            DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
             tools_install_dir: ~/miniforge3
-            build_workspace_dir: build_artifacts
-            docker_run_args: 
           - CONFIG: linux_aarch64_
+            DOCKER_IMAGE: quay.io/condaforge/linux-anvil-aarch64:alma10
             STORE_BUILD_ARTIFACTS: False
             UPLOAD_PACKAGES: True
-            os: ubuntu
-            runs_on: ['ubuntu-24.04-arm']
-            DOCKER_IMAGE: quay.io/condaforge/linux-anvil-aarch64:alma9
-            tools_install_dir: ~/miniforge3
             build_workspace_dir: build_artifacts
-            docker_run_args: 
+            docker_run_args:
+            free_disk_space: skip
+            os: ubuntu
+            pagefile_size: 0
+            resize_partitions: False
+            runs_on: ['ubuntu-24.04-arm']
+            tools_install_dir: ~/miniforge3
     steps:
 
     - name: Checkout code
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+    - name: Configure binfmt_misc
+      if: matrix.os == 'ubuntu'
+      shell: bash
+      run: |
+        if [[ "$(uname -m)" == "x86_64" ]]; then
+          docker run --rm --privileged multiarch/qemu-user-static:register --reset --credential yes
+        fi
 
     - name: Build on Linux
       id: build-linux
       if: matrix.os == 'ubuntu'
       env:
-        MINIFORGE_HOME: ${{ matrix.tools_install_dir }}
-        CONDA_BLD_PATH: ${{ matrix.build_workspace_dir }}
-        CONFIG: ${{ matrix.CONFIG }}
-        UPLOAD_PACKAGES: ${{ matrix.UPLOAD_PACKAGES }}
-        DOCKER_IMAGE: ${{ matrix.DOCKER_IMAGE }}
         CI: github_actions
-        CONDA_FORGE_DOCKER_RUN_ARGS: "${{ matrix.docker_run_args }}"
+        CONDA_BLD_PATH: ${{ matrix.build_workspace_dir }}
+        CONDA_FORGE_DOCKER_RUN_ARGS: ${{ matrix.docker_run_args }}
+        CONFIG: ${{ matrix.CONFIG }}
+        MINIFORGE_HOME: ${{ matrix.tools_install_dir }}
+        DOCKER_IMAGE: ${{ matrix.DOCKER_IMAGE }}
+        UPLOAD_PACKAGES: ${{ matrix.UPLOAD_PACKAGES }}
+        RATTLER_BUILD_COLOR: always
+        RATTLER_BUILD_ENABLE_GITHUB_INTEGRATION: 'true'
         BINSTAR_TOKEN: ${{ secrets.BINSTAR_TOKEN }}
         FEEDSTOCK_TOKEN: ${{ secrets.FEEDSTOCK_TOKEN }}
         STAGING_BINSTAR_TOKEN: ${{ secrets.STAGING_BINSTAR_TOKEN }}
       shell: bash
       run: |
-        if [[ "$(uname -m)" == "x86_64" ]]; then
-          echo "::group::Configure binfmt_misc"
-          docker run --rm --privileged multiarch/qemu-user-static:register --reset --credential yes
-        fi
+        export CONDA_BLD_PATH="${CONDA_BLD_PATH/#~/${HOME}}"
+        export FEEDSTOCK_NAME="$(basename $GITHUB_REPOSITORY)"
+        export GIT_BRANCH="$(basename $GITHUB_REF)"
+        export MINIFORGE_HOME="${MINIFORGE_HOME/#~/${HOME}}"
         export flow_run_id="github_$GITHUB_RUN_ID"
         export remote_url="https://github.com/$GITHUB_REPOSITORY"
         export sha="$GITHUB_SHA"
-        export FEEDSTOCK_NAME="$(basename $GITHUB_REPOSITORY)"
-        export GIT_BRANCH="$(basename $GITHUB_REF)"
         if [[ "${GITHUB_EVENT_NAME}" == "pull_request" ]]; then
           export IS_PR_BUILD="True"
         else
           export IS_PR_BUILD="False"
         fi
-        export MINIFORGE_HOME="${MINIFORGE_HOME/#~/${HOME}}"
-        export CONDA_BLD_PATH="${CONDA_BLD_PATH/#~/${HOME}}"
-        echo "::endgroup::"
         ./.scripts/run_docker_build.sh
 
     - name: Build on macOS
       id: build-macos
       if: matrix.os == 'macos'
       env:
-        MINIFORGE_HOME: ${{ matrix.tools_install_dir }}
+        CI: github_actions
         CONDA_BLD_PATH: ${{ matrix.build_workspace_dir }}
         CONFIG: ${{ matrix.CONFIG }}
+        MINIFORGE_HOME: ${{ matrix.tools_install_dir }}
         UPLOAD_PACKAGES: ${{ matrix.UPLOAD_PACKAGES }}
-        CI: github_actions
+        RATTLER_BUILD_COLOR: always
+        RATTLER_BUILD_ENABLE_GITHUB_INTEGRATION: 'true'
         BINSTAR_TOKEN: ${{ secrets.BINSTAR_TOKEN }}
         FEEDSTOCK_TOKEN: ${{ secrets.FEEDSTOCK_TOKEN }}
         STAGING_BINSTAR_TOKEN: ${{ secrets.STAGING_BINSTAR_TOKEN }}
       shell: bash
       run: |
+        export CONDA_BLD_PATH="${CONDA_BLD_PATH/#~/${HOME}}"
+        export FEEDSTOCK_NAME="$(basename $GITHUB_REPOSITORY)"
+        export GIT_BRANCH="$(basename $GITHUB_REF)"
+        export MINIFORGE_HOME="${MINIFORGE_HOME/#~/${HOME}}"
         export flow_run_id="github_$GITHUB_RUN_ID"
         export remote_url="https://github.com/$GITHUB_REPOSITORY"
         export sha="$GITHUB_SHA"
-        export FEEDSTOCK_NAME="$(basename $GITHUB_REPOSITORY)"
-        export GIT_BRANCH="$(basename $GITHUB_REF)"
         if [[ "${GITHUB_EVENT_NAME}" == "pull_request" ]]; then
           export IS_PR_BUILD="True"
         else
           export IS_PR_BUILD="False"
         fi
-        export MINIFORGE_HOME="${MINIFORGE_HOME/#~/${HOME}}"
-        export CONDA_BLD_PATH="${CONDA_BLD_PATH/#~/${HOME}}"
         ./.scripts/run_osx_build.sh
 
     - name: Build on windows
@@ -118,12 +130,14 @@ jobs:
         set "sha=%GITHUB_SHA%"
         call ".scripts\run_win_build.bat"
       env:
-        MINIFORGE_HOME: ${{ matrix.tools_install_dir }}
-        CONDA_BLD_PATH: ${{ matrix.build_workspace_dir }}
-        PYTHONUNBUFFERED: 1
-        CONFIG: ${{ matrix.CONFIG }}
         CI: github_actions
+        CONDA_BLD_PATH: ${{ matrix.build_workspace_dir }}
+        CONFIG: ${{ matrix.CONFIG }}
+        MINIFORGE_HOME: ${{ matrix.tools_install_dir }}
+        PYTHONUNBUFFERED: 1
         UPLOAD_PACKAGES: ${{ matrix.UPLOAD_PACKAGES }}
+        RATTLER_BUILD_COLOR: always
+        RATTLER_BUILD_ENABLE_GITHUB_INTEGRATION: 'true'
         BINSTAR_TOKEN: ${{ secrets.BINSTAR_TOKEN }}
         FEEDSTOCK_TOKEN: ${{ secrets.FEEDSTOCK_TOKEN }}
         STAGING_BINSTAR_TOKEN: ${{ secrets.STAGING_BINSTAR_TOKEN }}

--- a/.github/workflows/conda-build.yml
+++ b/.github/workflows/conda-build.yml
@@ -28,7 +28,7 @@ jobs:
             UPLOAD_PACKAGES: True
             build_workspace_dir: build_artifacts
             docker_run_args:
-            free_disk_space: skip
+            free_disk_space: quick
             os: ubuntu
             pagefile_size: 0
             resize_partitions: False
@@ -40,7 +40,7 @@ jobs:
             UPLOAD_PACKAGES: True
             build_workspace_dir: build_artifacts
             docker_run_args:
-            free_disk_space: skip
+            free_disk_space: quick
             os: ubuntu
             pagefile_size: 0
             resize_partitions: False
@@ -50,6 +50,14 @@ jobs:
 
     - name: Checkout code
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+    - name: Manage disk space
+      env:
+        FREE_DISK_SPACE: ${{ matrix.free_disk_space }}
+        OS: ${{ matrix.os }}
+      shell: bash
+      run: |
+        .scripts/free_disk_space.sh "${FREE_DISK_SPACE}"
     - name: Configure binfmt_misc
       if: matrix.os == 'ubuntu'
       shell: bash

--- a/.scripts/build_steps.sh
+++ b/.scripts/build_steps.sh
@@ -61,16 +61,37 @@ if [[ -f "${FEEDSTOCK_ROOT}/LICENSE.txt" ]]; then
 fi
 
 if [[ "${BUILD_WITH_CONDA_DEBUG:-0}" == 1 ]]; then
-    echo "rattler-build currently doesn't support debug mode"
-else
+    # differences between conda-build vs. rattler-build
+    #   - 1 step (conda debug + manually open shell) vs. 2 step (rb debug {setup, shell})
+    #   - recipe is positional vs. --recipe "${RECIPE_ROOT}"
+    #   - --output-id vs. --output-name
+    #   - --clobber-file vs. none
+    #   - none vs. --target-platform
+    export CONDA_BLD_PATH="${CONDA_BLD_PATH:-${FEEDSTOCK_ROOT}/build_artifacts}"
+    rattler-build debug setup \
+        --recipe "${RECIPE_ROOT}" \
+        -m "${CI_SUPPORT}/${CONFIG}.yaml" \
+        ${EXTRA_CB_OPTIONS:-} \
+        ${BUILD_OUTPUT_ID:+--output-name "${BUILD_OUTPUT_ID}"} \
+        --target-platform "${HOST_PLATFORM}"
 
-    rattler-build build --recipe "${RECIPE_ROOT}" \
-     -m "${CI_SUPPORT}/${CONFIG}.yaml" \
-     ${EXTRA_CB_OPTIONS:-} \
-     --target-platform "${HOST_PLATFORM}" \
-     --extra-meta flow_run_id="${flow_run_id:-}" \
-     --extra-meta remote_url="${remote_url:-}" \
-     --extra-meta sha="${sha:-}"
+    rattler-build debug shell
+else
+    # differences between conda-build vs. rattler-build
+    #   - recipe is positional vs. --recipe "${RECIPE_ROOT}"
+    #   - --suppress-variables vs. none
+    #   - --clobber-file vs. none
+    #   - none vs. --target-platform
+    #   - --extra-meta a=b c=d vs. --extra-meta a=b --extra-meta c=d
+
+    rattler-build build \
+        --recipe "${RECIPE_ROOT}" \
+        -m "${CI_SUPPORT}/${CONFIG}.yaml" \
+        ${EXTRA_CB_OPTIONS:-} \
+        --target-platform "${HOST_PLATFORM}" \
+        --extra-meta flow_run_id="${flow_run_id:-}" \
+        --extra-meta remote_url="${remote_url:-}" \
+        --extra-meta sha="${sha:-}"
     ( startgroup "Inspecting artifacts" ) 2> /dev/null
 
     # inspect_artifacts was only added in conda-forge-ci-setup 4.9.4

--- a/.scripts/free_disk_space.sh
+++ b/.scripts/free_disk_space.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+
+set -ex
+
+FREE_DISK_SPACE=${1}
+
+if [[ ${FREE_DISK_SPACE} == skip ]]; then
+  exit 0
+fi
+
+df -h
+
+case ${OS} in
+  ubuntu)
+    DIRS_TO_REMOVE=(
+      /opt/ghc
+      /opt/hostedtoolcache
+      /usr/lib/jvm
+      /usr/local/.ghcup
+      /usr/local/lib/android
+      /usr/local/share/powershell
+      /usr/share/dotnet
+      /usr/share/swift
+    )
+
+    sudo rm -rf "${DIRS_TO_REMOVE[@]}"
+
+    if type apt-get; then
+      BROWSERS="firefox google-chrome-stable microsoft-edge-stable"
+      BROWSERS_TO_REMOVE=$(dpkg --get-selections $BROWSERS 2>/dev/null | awk '{print $1}')
+      if [[ -n ${BROWSERS_TO_REMOVE} ]]; then
+        sudo apt-get remove --purge -y $BROWSERS_TO_REMOVE
+      fi
+
+      sudo apt-get autoremove -y >& /dev/null
+      sudo apt-get autoclean -y >& /dev/null
+    fi
+
+    if [[ ${FREE_DISK_SPACE} == max ]] && type docker; then
+      sudo docker image prune --all --force
+    fi
+    ;;
+  macos)
+    DIRS_TO_REMOVE=(
+      /Users/runner/Library/Android
+      /Users/runner/.dotnet
+      /Users/runner/hostedtoolcache
+    )
+    rm -rf "${DIRS_TO_REMOVE[@]}"
+    ;;
+  windows)
+    DIRS_TO_REMOVE=(
+      C:/hostedtoolcache/windows
+      C:/Android
+    )
+
+    # rm is one of the fastest methods to remove files on Windows
+    rm -rf "${DIRS_TO_REMOVE[@]}"
+    ;;
+esac
+
+df -h

--- a/.scripts/run_docker_build.sh
+++ b/.scripts/run_docker_build.sh
@@ -96,6 +96,14 @@ if [ "${DOCKER_EXECUTABLE}" = "podman" ]; then
     fi
 fi
 
+# When running on GitHub Actions, mount the step summary file into the container
+# and point GITHUB_STEP_SUMMARY at it so that rattler-build's GitHub integration
+# can write its summary. GitHub writes the file out to the job summary after the
+# step finishes.
+if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
+    DOCKER_RUN_ARGS="${DOCKER_RUN_ARGS} -v ${GITHUB_STEP_SUMMARY}:/home/conda/github_step_summary:rw${VOLUME_SUFFIX},delegated -e GITHUB_STEP_SUMMARY=/home/conda/github_step_summary"
+fi
+
 ( endgroup "Configure Docker" ) 2> /dev/null
 ( startgroup "Start Docker" ) 2> /dev/null
 
@@ -107,17 +115,20 @@ ${DOCKER_EXECUTABLE} pull "${DOCKER_IMAGE}"
 ${DOCKER_EXECUTABLE} run ${DOCKER_RUN_ARGS} \
            -v "${RECIPE_ROOT}":/home/conda/recipe_root:rw${VOLUME_SUFFIX},delegated \
            -v "${FEEDSTOCK_ROOT}":/home/conda/feedstock_root:rw${VOLUME_SUFFIX},delegated \
-           -e CONFIG \
-           -e HOST_USER_ID \
-           -e UPLOAD_PACKAGES \
-           -e IS_PR_BUILD \
-           -e GIT_BRANCH \
-           -e UPLOAD_ON_BRANCH \
-           -e CI \
-           -e FEEDSTOCK_NAME \
-           -e CPU_COUNT \
-           -e BUILD_WITH_CONDA_DEBUG \
            -e BUILD_OUTPUT_ID \
+           -e BUILD_WITH_CONDA_DEBUG \
+           -e CI \
+           -e CONFIG \
+           -e CPU_COUNT \
+           -e FEEDSTOCK_NAME \
+           -e GIT_BRANCH \
+           -e GITHUB_ACTIONS \
+           -e HOST_USER_ID \
+           -e IS_PR_BUILD \
+           -e RATTLER_BUILD_COLOR \
+           -e RATTLER_BUILD_ENABLE_GITHUB_INTEGRATION \
+           -e UPLOAD_ON_BRANCH \
+           -e UPLOAD_PACKAGES \
            -e flow_run_id \
            -e remote_url \
            -e sha \

--- a/.scripts/run_osx_build.sh
+++ b/.scripts/run_osx_build.sh
@@ -94,7 +94,15 @@ if [[ -f LICENSE.txt ]]; then
 fi
 
 if [[ "${BUILD_WITH_CONDA_DEBUG:-0}" == 1 ]]; then
-    echo "rattler-build does not currently support debug mode"
+    export CONDA_BLD_PATH="${CONDA_BLD_PATH:-${FEEDSTOCK_ROOT:-$PWD}/build_artifacts}"
+    rattler-build debug setup \
+        --recipe ./recipe \
+        -m ./.ci_support/${CONFIG}.yaml \
+        --target-platform "${HOST_PLATFORM}" \
+        ${BUILD_OUTPUT_ID:+--output-name "${BUILD_OUTPUT_ID}"} \
+        ${EXTRA_CB_OPTIONS:-}
+
+    rattler-build debug shell
 else
 
     if [[ "${HOST_PLATFORM}" != "${BUILD_PLATFORM}" ]]; then

--- a/build-locally.py
+++ b/build-locally.py
@@ -98,7 +98,10 @@ def main(args=None):
     p.add_argument(
         "--debug",
         action="store_true",
-        help="Setup debug environment using `conda debug`",
+        help=(
+            "Setup debug environment using `conda debug` "
+            "(or `rattler-build debug` for rattler-build recipes)"
+        ),
     )
     p.add_argument("--output-id", help="If running debug, specify the output to setup.")
 

--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -1,9 +1,8 @@
-azure:
-  free_disk_space: true
 workflow_settings:
   build_workspace_dir:
     - value: C:\bld\
       os: win
+  free_disk_space: quick
 bot:
   abi_migration_branches:
   - qt5

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -20,6 +20,7 @@ fi
 if test `uname` = "Darwin"; then
   # else cmake erroneously finds ${SDKROOT}/usr/lib/libnetwork.tbd
   CMAKE_ARGS="${CMAKE_ARGS} -DFWNetworkInternal:FILEPATH=${SDKROOT}/System/Library/Frameworks/Network.framework"
+  CMAKE_ARGS="${CMAKE_ARGS} -DFEATURE_vulkan=ON"
 fi
 
 QT_SUBMODULES="qtbase;\

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -10,9 +10,10 @@ if [[ "$build_platform" != "$target_platform" ]]; then
     CMAKE_ARGS="${CMAKE_ARGS} -DBUILD_WITH_PCH=OFF"
 fi
 
+CMAKE_ARGS="${CMAKE_ARGS} -DFEATURE_vulkan=ON"
+
 if [[ $(uname) == "Linux" ]]; then
   CMAKE_ARGS="${CMAKE_ARGS} -DFEATURE_egl=ON -DFEATURE_eglfs=ON -DFEATURE_xcb=ON -DFEATURE_xcb_xlib=ON -DFEATURE_xkbcommon=ON"
-  CMAKE_ARGS="${CMAKE_ARGS} -DFEATURE_vulkan=ON"
   CMAKE_ARGS="${CMAKE_ARGS} -DFEATURE_wayland=ON"
   CMAKE_ARGS="${CMAKE_ARGS} -DFEATURE_liburing=OFF"
 fi
@@ -20,7 +21,6 @@ fi
 if test `uname` = "Darwin"; then
   # else cmake erroneously finds ${SDKROOT}/usr/lib/libnetwork.tbd
   CMAKE_ARGS="${CMAKE_ARGS} -DFWNetworkInternal:FILEPATH=${SDKROOT}/System/Library/Frameworks/Network.framework"
-  CMAKE_ARGS="${CMAKE_ARGS} -DFEATURE_vulkan=ON"
 fi
 
 QT_SUBMODULES="qtbase;\

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -36,7 +36,7 @@ source:
     target_directory: opengl32sw
 
 build:
-  number: 1
+  number: 2
   # bumping qt version requires a 2-staged build as cross builds require the native package with the same version
   # Once should be careful and "merge" when the native CIs pass
   # Then on main:
@@ -95,10 +95,13 @@ requirements:
     - double-conversion
     - libtiff
     - libwebp
+    - libvulkan-headers
+    - libvulkan-loader
+    - if: osx
+      then:
+        - moltenvk
     - if: not osx
       then:
-        - libvulkan-headers
-        - libvulkan-loader
         - freetype
     - if: not win
       then:
@@ -221,6 +224,10 @@ tests:
         then:
           - test -f $PREFIX/lib/qt6/plugins/platforms/libqxcb.so
           - test -f $PREFIX/lib/qt6/plugins/platforms/libqeglfs.so
+      - if: osx
+        then:
+          - test -f $PREFIX/include/qt6/QtGui/QVulkanInstance
+          - test -f $PREFIX/lib/qt6/plugins/platforms/libqcocoa${SHLIB_EXT}
       - if: unix
         then:
           - test -f $PREFIX/lib/qt6/plugins/sqldrivers/libqsqlite${SHLIB_EXT}
@@ -252,6 +259,7 @@ tests:
         - test/qrc_qml.cpp
         - test/test_qmimedatabase.cpp
         - test/test_qlibraryinfo_prefixpath.cpp
+        - test/test_qvulkaninstance.cpp
         - test/CMakeLists.txt
         - test/main.pro
 

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -100,8 +100,7 @@ requirements:
     - if: osx
       then:
         - moltenvk
-    - if: not osx
-      then:
+      else:
         - freetype
     - if: not win
       then:
@@ -204,6 +203,7 @@ tests:
           - test -f $PREFIX/lib/libQt6Quick${SHLIB_EXT}
           - test -f $PREFIX/lib/libQt6Widgets${SHLIB_EXT}
           - test -f $PREFIX/lib/libQt6Xml${SHLIB_EXT}
+          - test -f $PREFIX/include/qt6/QtGui/QVulkanInstance
         else:
           - if not exist %PREFIX%\\Library\\include\\qt6\\QtCore exit 1
           - if not exist %PREFIX%\\Library\\lib\\Qt6Core.lib exit 1
@@ -226,7 +226,6 @@ tests:
           - test -f $PREFIX/lib/qt6/plugins/platforms/libqeglfs.so
       - if: osx
         then:
-          - test -f $PREFIX/include/qt6/QtGui/QVulkanInstance
           - test -f $PREFIX/lib/qt6/plugins/platforms/libqcocoa${SHLIB_EXT}
       - if: unix
         then:
@@ -235,11 +234,21 @@ tests:
           # We needed to add a related flag, but these two SO files should be part of the
           # qt6-wayland conda package
           - test ! -f $PREFIX/lib/libQt6WaylandCompositor${SHLIB_EXT}
+      - if: unix
+        then:
+          - cmake -S test -B test-build
+          - cmake --build test-build
+          - ctest --test-dir test-build --output-on-failure
+        else:
+          - cmake -G"NMake Makefiles" -DCMAKE_PREFIX_PATH="%LIBRARY_PREFIX%" -S test -B test-build
+          - cmake --build test-build --config Release
+          - ctest --test-dir test-build -C Release --output-on-failure
     requirements:
       run:
         - ${{ compiler('cxx') }}
         - ${{ stdlib('c') }}
         - cmake >=3.16
+        - libvulkan-headers
         - if: unix
           then: make
         - if: linux

--- a/recipe/test/CMakeLists.txt
+++ b/recipe/test/CMakeLists.txt
@@ -4,7 +4,7 @@ set (CMAKE_BUILD_TYPE "Release" CACHE STRING "build type")
 
 project (qt-main-test CXX)
 
-find_package (Qt6 CONFIG REQUIRED COMPONENTS Core)
+find_package (Qt6 CONFIG REQUIRED COMPONENTS Core Gui)
 
 add_executable (hello main.cpp)
 target_link_libraries (hello Qt6::Core)
@@ -15,6 +15,10 @@ target_link_libraries (test_qmimedatabase Qt6::Core)
 add_executable (test_qlibraryinfo_prefixpath test_qlibraryinfo_prefixpath.cpp)
 target_link_libraries (test_qlibraryinfo_prefixpath Qt6::Core)
 
+add_executable (test_qvulkaninstance test_qvulkaninstance.cpp)
+target_link_libraries (test_qvulkaninstance Qt6::Gui)
+
 enable_testing ()
 add_test (NAME test_qmimedatabase COMMAND test_qmimedatabase)
 add_test (NAME test_qlibraryinfo_prefixpath COMMAND test_qlibraryinfo_prefixpath)
+add_test (NAME test_qvulkaninstance COMMAND test_qvulkaninstance)

--- a/recipe/test/test_qvulkaninstance.cpp
+++ b/recipe/test/test_qvulkaninstance.cpp
@@ -1,0 +1,13 @@
+#include <QtGui/qtguiglobal.h>
+
+#if !QT_CONFIG(vulkan)
+#error "QtGui was built without Vulkan support"
+#endif
+
+#include <QVulkanInstance>
+
+int main()
+{
+    QVulkanInstance instance;
+    return instance.vkInstance() == VK_NULL_HANDLE ? 0 : 1;
+}


### PR DESCRIPTION
Qt's Vulkan feature is currently enabled on Linux but disabled on macOS. The historical macOS blocker was the lack of a packaged MoltenVK implementation; conda-forge now provides `moltenvk` for both macOS architectures.

This change:

- makes `libvulkan-headers` and `libvulkan-loader` host dependencies available on macOS;
- adds `moltenvk` as a macOS host dependency;
- enables `FEATURE_vulkan` in the Darwin build;
- adds a compile-time `QT_CONFIG(vulkan)` regression test using `QVulkanInstance`;
- checks that the packaged QtGui Vulkan header and Cocoa platform plugin are present;
- increments the build number from 1 to 2.

Local macOS arm64 validation was completed on an Apple M1 Pro:

- the full `qt6-main` 6.11.1 feedstock build and package tests passed;
- the Qt configuration reported `FEATURE_vulkan:BOOL=ON`;
- the package test compiled and linked `QVulkanInstance` against `Qt6::Gui`;
- an isolated runtime environment loaded the packaged MoltenVK ICD through the conda-forge Vulkan loader;
- `QVulkanInstance::create()` succeeded;
- a Cocoa `QWindow` using `QSurface::VulkanSurface` produced a non-null Vulkan surface;
- MoltenVK identified the Apple M1 Pro and reported Vulkan 1.4 support;
- the rendered package metadata included the Vulkan loader and MoltenVK runtime dependencies.

The local artifact was:

`qt6-main-6.11.1-pl5321hd92956d_2.conda`

SHA-256:

`71e4ea3cd7a5ff1ffe814758cdb9f07230dc3c63dde724cfe5e77a6590099a2f`

Checklist

- [x] Bumped the build number
- [x] Added focused build and package tests
- [x] Completed a native macOS arm64 build
- [x] Tested the packaged Vulkan loader and MoltenVK ICD in an isolated environment
- [x] Tested Cocoa Vulkan surface creation
