### PR TITLE
Re-enable Qt 6.8.4 cross builds

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,9 +25,9 @@ source:
     folder: opengl32sw                                                                                            # [win64]
 
 build:
-  number: 0
+  number: 1
   # bumping qt version requires a 2-staged build as cross builds require the native package with the same version
-  skip: true  # [build_platform != target_platform]
+  # skip: true  # [build_platform != target_platform]
   detect_binary_files_with_prefix: true
   run_exports:
     - {{ pin_subpackage('qt6-main', max_pin='x.x') }}


### PR DESCRIPTION
Follow-up to #408.

The native Qt 6.8.4 build 0 packages are now available for both `linux-64` and `osx-64`, so this completes the second build stage:

- re-enable the cross-build variants
- bump the recipe build number from 0 to 1

Validation:
- confirmed `qt6-main 6.8.4` build 0 is available on conda-forge for the Linux and macOS build platforms
- native and Linux ARM cross variants both render successfully
- the cross variant resolves the exact `qt6-main 6.8.4` bootstrap dependency
- `conda-smithy recipe-lint --conda-forge` passes

Full platform builds are left to conda-forge CI.